### PR TITLE
Implement intelligent relativity check for process-file-field

### DIFF
--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -436,7 +436,7 @@ notes project before calling any org-roam functions."
                ;; Check if dir is different
                ((not (equal dir-cur dir))
                 (throw 'no-dir nil))
-                ;; Check name-base
+               ;; Check name-base
                (t
                 (unless (equal name-base-cur name-base)
                   (setq rel 'same-dir))))))

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -419,7 +419,8 @@ notes project before calling any org-roam functions."
   "Check the relativity between members of a list of PATHS.
 - If every file has the same name-base, return 'same-name-base.
 - If every file is in the same directory, return 'same-dir.
-- Otherwise, return nil."
+- Otherwise, return nil.
+See `org-roam-bibtex-process-file-field-intelligently' for details."
   (let (name-base dir rel)
     (catch 'no-dir
       (or (dolist (path paths rel)

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -476,24 +476,26 @@ to enter"
                      ;; Strip invalid files
                      (remove "/")))
          (intelligent? org-roam-bibtex-process-file-field-intelligently)
-         (rel (when intelligent?
-                (org-roam-bibtex--check-relativity paths)))
-         (paths-alist
-          (mapcar (if intelligent?
-                      (lambda (path)
-                        (let ((name-base (file-name-base path))
-                              (ext (file-name-extension path)))
-                          (pcase rel
-                            ('same-name-base (cons ext path))
-                            ('same-dir (cons name-base path))
-                            (_ path))))
-                    (lambda (path)
-                      (cons path path)))
-                  paths)))
+         paths-alist)
+    (when intelligent?
+      (let ((rel (org-roam-bibtex--check-relativity paths)))
+        (setq paths-alist (mapcar (lambda (path)
+                   (let ((name-base (file-name-base path))
+                         (ext (file-name-extension path)))
+                     (pcase rel
+                       ('same-name-base (cons ext path))
+                       ('same-dir (cons name-base path))
+                       (_ path))))
+                 paths))))
     (if (= (length paths) 1)
         (car paths)
-      (cdr (assoc (completing-read "File to use: " paths-alist)
-                  paths-alist)))))
+      (let ((result (completing-read "File to use: "
+                                     (if intelligent?
+                                         paths-alist
+                                       paths))))
+        (if intelligent?
+            (cdr (assoc paths-alist result))
+          result)))))
 
 (provide 'org-roam-bibtex)
 ;;; org-roam-bibtex.el ends here


### PR DESCRIPTION
When there are multiple files in a `file` BibTeX field, check the relativity between the different candidates:
- If every file has the same name-base, return 'same-name-base.
- If every file is in the same directory, return 'same-dir.
- Otherwise, return nil.
-----
This is a follow-up to #5.  I like the idea of making the function intelligent, but it took quite a bit of head-scratching to figure it out, and I might have forgotten some edge-cases.

I welcome your feedback!