### PR TITLE
Stop formatting citekeys as Org-ref links in ROAM_KEY

### DIFF
--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -455,8 +455,7 @@ perspective will be switched to the Org-roam notes project before
 calling any Org-roam functions."
   (unless org-roam-mode
     (org-roam-mode +1))
-  (let* ((citekey-formatted (format (or org-roam-bibtex-citekey-format "%s") citekey))
-         (note-info (list (cons 'ref citekey-formatted))))
+  (let* ((note-info (list (cons 'ref citekey))))
     ;; Optionally switch to the notes perspective
     (when org-roam-bibtex-switch-persp
       (org-roam-bibtex--switch-perspective))
@@ -489,7 +488,7 @@ calling any Org-roam functions."
           (if org-roam-bibtex-templates
               (let ((org-roam-capture--context 'ref)
                     (org-roam-capture--info (list (cons 'title title)
-                                                  (cons 'ref citekey-formatted)
+                                                  (cons 'ref citekey)
                                                   (cons 'slug (org-roam--title-to-slug citekey)))))
                 (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h)
                 (org-roam--capture))


### PR DESCRIPTION
The presence of the `cite:` in the file-metadata tag `#+ROAM_KEY:` seems to
have been warranted at some point in Org-roam, but this doesn’t seem to be the
case anymore.  Since the Org-ref link doesn’t work in that context, there’s
even less of a reason to keep it around.

------

Discussed in #21.  I'm holding off on this until I get the confirmation from @jethrokuan that we're not borking stuff upstream by doing it that way.