### PR TITLE
Raise error if =key= is not preformated in orb-preformat-keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Below shows how this can be used to integrate with [org-noter](https://github.co
 
 ```el
 (setq orb-preformat-keywords
-   '("citekey" "title" "url" "file" "author-or-editor" "keywords"))
+   '(("citekey" . "=key=") "title" "url" "file" "author-or-editor" "keywords"))
 
 (setq orb-templates
       '(("r" "ref" plain (function org-roam-capture--get-point)

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -301,6 +301,11 @@ is a BibTeX entry as returned by `bibtex-completion-get-entry'."
          (plst (cdr template))          ; org-roam capture properties are here
          (rx "\\(%\\^{[[:alnum:]-_]*}\\)") ; regexp for org-capture prompt wildcard
          lst)
+    ;; Error if =key= is not preformatted in `orb-preformat-keywords'
+    (unless (or (member "=key=" kwds)
+                (rassoc "=key=" kwds))
+      (org-roam--with-template-error 'orb-preformat-keywords
+        (user-error "No preformating found for `=key='")))
     ;; First run:
     ;; 1) Make a list of (rplc-s field-value match-position) for the second run
     ;; 2) replace org-roam-capture wildcards


### PR DESCRIPTION
Someone on Slack ran into a problem with one of the examples on the `README.me`:
https://github.com/org-roam/org-roam-bibtex/blob/850c238b2f36ac73e600937e7851c1f36defbe0f/README.md#L249-L250

`citekey` does not preformat `=key=` because it has no knowledge of it.  I've considered solving this problem by validating `orb-preformat-keywords` and `push`ing `=key=` if it didn't exist, but I didn't like the way it looked.  So, I've elected to raise an error instead.  I think it should be sufficiently informative:
> No preformating found for ‘=key=’.  Please adjust ‘orb-preformat-keywords’