### PR TITLE
Redesign structure of org-roam-bibtex package

### DIFF
--- a/orb-core.el
+++ b/orb-core.el
@@ -1,0 +1,90 @@
+;;; orb-core.el --- Org Roam Bibtex: Core library -*- coding: utf-8; lexical-binding: t -*-
+
+;; Copyright © 2020 Mykhailo Shevchuk <mail@mshevchuk.com>
+;; Copyright © 2020 Leo Vivier <leo.vivier+dev@gmail.com>
+
+;; Author: Mykhailo Shevchuk <mail@mshevchuk.com>
+;;         Leo Vivier <leo.vivier+dev@gmail.com>
+;; URL: https://github.com/org-roam/org-roam-bibtex
+;; Keywords: org-mode, roam, convenience, bibtex, helm-bibtex, ivy-bibtex, org-ref
+;; Version: 0.2.3
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+;;
+;; This file provides org-roam-bibtex' dependencies and thus should
+;; normally be required by org-roam-bibtex feature libraries.  It
+;; defines customize groups and provides general utility functions
+;; that depend on extra features provided through org-roam,
+;; bibtex-completion and their dependencies.
+
+;;; Code:
+;; * Library requires
+;;
+;; 1. org-roam requires org, org-ref (with many dependencies),
+;; org-element, dash, f, s, emacsql, emacsql-sqlite;
+;; 2. bibtex-completion additionally requires parsebib and biblio;
+;;
+;; So all these libraries are always at our disposal
+;;
+(require 'org-roam)
+(require 'bibtex-completion)
+
+(require 'orb-utils)
+
+;; Customize groups
+(defgroup org-roam-bibtex nil
+  "Org-ref and Bibtex-completion integration for Org-roam."
+  :group 'org-roam
+  :prefix "orb-")
+
+(defgroup orb-note-actions nil
+  "Orb Note Actions - run actions useful in note's context."
+  :group 'org-roam-bibtex
+  :prefix "orb-note-actions-")
+
+;;;###autoload
+(defun orb-process-file-field (citekey)
+  "Process the 'file' BibTeX field and resolve if there are multiples.
+Search the disk for the document associated with this BibTeX
+entry.  The disk matching is based on looking in the
+`bibtex-completion-library-path' for a file with the
+CITEKEY.
+
+\(Mendeley, Zotero, normal paths) are all supported.  If there
+are multiple files found the user is prompted to select which one
+to enter"
+  (let* ((entry (bibtex-completion-get-entry citekey))
+         (paths (bibtex-completion-find-pdf entry)))
+    (if (= (length paths) 1)
+        (car paths)
+      (completing-read "File to use: " paths))))
+
+;;;###autoload
+(defun orb-find-note-file (citekey)
+  "Find note file associated from BibTeX’s CITEKEY.
+Returns the path to the note file, or nil if it doesn’t exist."
+  (let* ((completions (org-roam--get-ref-path-completions)))
+    (plist-get (cdr (assoc citekey completions)) :path)))
+
+(provide 'orb-core)
+;;; orb-core.el ends here
+;; Local Variables:
+;; fill-column: 70
+;; End:

--- a/orb-utils.el
+++ b/orb-utils.el
@@ -1,4 +1,4 @@
-;;; orb-macs.el --- Connector between Org-roam, BibTeX-completion, and Org-ref -*- coding: utf-8; lexical-binding: t -*-
+;;; orb-utils.el --- Org Roam BibTeX: Utility macros and functions -*- coding: utf-8; lexical-binding: t -*-
 
 ;; Copyright © 2020 Mykhailo Shevchuk <mail@mshevchuk.com>
 ;; Copyright © 2020 Leo Vivier <leo.vivier+dev@gmail.com>
@@ -8,7 +8,7 @@
 ;; URL: https://github.com/org-roam/org-roam-bibtex
 ;; Keywords: org-mode, roam, convenience, bibtex, helm-bibtex, ivy-bibtex, org-ref
 ;; Version: 0.2.3
-;; Package-Requires: ((emacs "26.1") (f "0.20.0") (s "1.12.0") (org "9.3") (org-roam "1.0.0") (bibtex-completion "2.0.0"))
+;; Package-Requires: ((emacs "26.1"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -29,8 +29,10 @@
 
 ;;; Commentary:
 ;;
-;; This file contains macros and helper functions used accross different
-;; org-mode-bibtex modules.
+;; This file contains utility macros and helper functions used accross
+;; different org-mode-bibtex modules.  This library may be required
+;; directly or through orb-core.el.  Definitions in this file should
+;; only depend on built-in Emacs libraries.
 
 ;;; Code:
 ;; * Library requires
@@ -53,8 +55,8 @@ Format is `orb-citekey-format'."
                    (length orb-citekey-format)))))
     (substring citekey beg end)))
 
-(provide 'orb-macs)
-;;; orb-macs.el ends here
+(provide 'orb-utils)
+;;; orb-utils.el ends here
 ;; Local Variables:
 ;; fill-column: 70
 ;; End:


### PR DESCRIPTION
A continuation of thoughts expressed in #13 

1) `orb-core.el` as a central dependency point. It requires `org-roam` and `bibtex-completion`. It is supposed to be required by user interface libraries. It contains `defgroup` definitions and general utility functions that depend on `org-roam`, `bibtex-completion` and other packages not included in Emacs. It itself does not require any user interface libraries but may require utility libraries.
2) `orb-utils.el` - general purpose utilities that do not depend on extra packages, only built-in Emacs libraries (an exception can be made for general purpose extra libraries such as `dash`, `f`, `s`). If a function requires anything from `org-roam`, `bibtex-comletion` or other specialized libraries, it should go into `orb-core.el` or a specialized utility library.
3) user interface libraries - multiple entry points into the package. They depend on `orb-core`, `orb-utils` and perhaps on other user interface libraries. However, if such a library depends on another user interface library, then that code should probably be refactored into `orb-core` or `orb-utils` or yet another utility library.