### PR TITLE
autokey functionality: format field

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,14 @@ You can get `org-roam-bibtex` up and running by pasting the following sexps in y
 ```el
 ;; If you installed via MELPA
 (use-package org-roam-bibtex
+  :after org-roam
   :hook (org-roam-mode . org-roam-bibtex-mode)
   :bind (:map org-mode-map
          (("C-c n a" . orb-note-actions))))
 
 ;; If you cloned the repository
 (use-package org-roam-bibtex
+  :after org-roam
   :load-path "~/projects/org-roam-bibtex/" ;Modify with your own path
   :hook (org-roam-mode . org-roam-bibtex-mode)
   :bind (:map org-mode-map

--- a/orb-core.el
+++ b/orb-core.el
@@ -275,12 +275,14 @@ instead of `orb-autokey-format'."
     (let ((year (or (bibtex-completion-get-value "year" entry)
                     (bibtex-completion-get-value "date" entry))))
       (if (or (not year)
-              (string-empty-p year))
+              (string-empty-p year)
+              (string= year orb-autokey-empty-field-token))
           (while (string-match y-rx str)
             (setq str (replace-match orb-autokey-empty-field-token
                                      t nil str 1)))
         (while (string-match y-rx str)
-          (setq str (replace-match
+          (setq year (format "%04d" (string-to-number year))
+                str (replace-match
                      (format "%s" (if (match-string 3 str)
                                       (substring year 2 4)
                                     (substring year 0 4)))

--- a/orb-core.el
+++ b/orb-core.el
@@ -264,7 +264,7 @@ instead of `orb-autokey-format'."
                      :field (if (match-string 2 str) "pagetotal"
                               "pages")
                      :delimiter (match-string 3 str)
-                     :words 1)
+                     :words "1")
                  t nil str 1)))
     str))
 

--- a/orb-core.el
+++ b/orb-core.el
@@ -48,7 +48,9 @@
 
 (require 'orb-utils)
 
-;; Customize groups
+;; * Customize groups (global)
+;; All modules should put their `defgroup' definitions here
+
 (defgroup org-roam-bibtex nil
   "Org-ref and Bibtex-completion integration for Org-roam."
   :group 'org-roam
@@ -58,6 +60,8 @@
   "Orb Note Actions - run actions useful in note's context."
   :group 'org-roam-bibtex
   :prefix "orb-note-actions-")
+
+;; Various utility functions
 
 ;;;###autoload
 (defun orb-process-file-field (citekey)
@@ -85,52 +89,95 @@ Returns the path to the note file, or nil if it doesn’t exist."
 
 ;; * Automatic generation of citation keys
 
-(defvar orb-autokey-format)
-;; debug
-(setq orb-autokey-format "%y-%e{(format \"%%y\")}-%a*[2][3][_]-%T[3][2][.]")
+(defcustom orb-autokey-format "%a%y%T[4][1]"
+  "Format string for automatically generated citation keys.
 
-(defvar orb-autokey-titlewords-ignore bibtex-autokey-titleword-ignore
+Supported wildcards:
+
+Basic
+==========
+
+ %a         |author| - first author's (or editor's) last name
+ %t         |title | - first word of title
+ %f{field}  |field | - first word of arbitrary field
+ %y         |year  | - year YYYY
+ %p         |page  | - first page
+ %e{(expr)} |elisp | - execute elisp expression
+
+Extended
+==========
+
+1. Capitalized versions:
+
+ %A        |author| >
+ %T        |title | >  Same as %a,%t,%f{field} but
+ %F{field} |field | >  preserve orignial capitalization
+
+2. Starred versions
+
+ %a*, %A* |author| - include author's (editor's) initials
+ %t*, %T* |title | - do not ignore words in `orb-autokey-titlewords-ignore'
+ %y*      |year  | - year's last two digits __YY
+ %p*      |page  | - use \"pagetotal\" field instead of default \"pages\"
+
+3. Optional parameters
+
+ %a[N][M][D]        |author| >
+ %t[N][M][D]        |title | > include first N words/names
+ %f{field}[N][M][D] |field | > include at most M first characters of word/name
+ %p[D]              |page  | > put delimiter D between words
+
+N and M should be a single digit 1-9. Putting more digits or any
+other symbols will lead to ignoring the optional parameter and
+those following it altogether.  D should be a single alphanumeric
+symbol or one of `-_.:|'.
+
+Optional parameters work both with capitalized and starred
+versions where applicable.
+
+4. Elisp expression
+
+ - can be anything
+ - should return a string or nil
+ - will be evaluated before expanding other wildcards and therefore
+can insert other wildcards
+ - will have `entry' variable bound to the value of BibTeX entry the key
+is being generated for, as returned by `bibtex-completion-get-entry'.
+The variable may be safely manipulated in a destructive manner.
+
+%e{(or (bibtex-completion-get-value \\\"volume\\\" entry) \\\"N/A\\\")}
+%e{(my-function entry)}
+
+Key generation is performed by  `orb-autokey-generate-key'."
+  :risky t
+  :type 'string
+  :group 'org-roam-bibtex)
+
+(defcustom orb-autokey-titlewords-ignore (copy-tree bibtex-autokey-titleword-ignore)
   "Patterns from title that will be ignored during key generation.
 Every element is a regular expression to match parts of the title
 that should be ignored during automatic key generation.  Case
 sensitive.
 
-Default value is set from `bibtex-autokey-titleword-ignore'.")
+Default value is set from `bibtex-autokey-titleword-ignore'."
+  :type '(repeat :tag "Regular expression" regexp)
+  :group 'org-roam-bibtex)
 
-(defun orb-autokey-generate-key (entry)
-  "Generate citation key from ENTRY according to orb-autokey-format.
-
-%A*[2][5][_] - first two author's last names plus initials delimited with _, retain capitals
-%a*[2][5][_] - first two author's last names plus initials delimited with _, downcase
-
-%y - year xxxx
-%Y - year xx (two last digits)
-%p - first page
-%p[-] first and last page delimited with -
-
-%T*[5][2][:] - first five characters of first 2 words in title delimited with :, retain capitals
-%t*[5][2][:] - first five characters of first 2 words in title delimited with :, downcase
-starred version - ignore words from `orb-autokey
-
-%F{field}[3][2][-] - 2 first characters of first 3 words in field field delimited with -, retain capitals
-%f{field}[3][2][-] - 2 first characters of first 3 words in field field delimited with -, downcase
-
-%e{(expr)} - elisp expression that should return string, possibly with
-the above wildcards.  It has a variable entry bound which is the current bibtex entry."
+(defun orb-autokey-generate-key (entry &optional control-string)
+  "Generate citation key from ENTRY according to `orb-autokey-format'.
+Return a string.  If optional CONTROL-STRING is non-nil, use it
+instead of `orb-autokey-format'."
   (let* ((case-fold-search nil)
-         (str (copy-seq orb-autokey-format))
+         (str (or control-string orb-autokey-format))
+         ;; author wildcard regexp
          (a-rx
           (rx (group-n 1
                        (or "%a" (group-n 2 "%A"))
                        (opt (group-n 3 "*"))
-                       (opt (and "[" (group-n 4 digit) "]"))
-                       (opt (and "[" (group-n 5 digit) "]"))
-                       (opt (and "[" (group-n 6 (any alnum "_.:|-")) "]")))))
-         (y-rx (rx (group-n 1 "%y")))
-         (Y-rx (rx (group-n 1 "%Y")))
-         (p-rx
-          (rx (group-n 1 "%p"
-                       (opt (and "[" (group-n 2 (any alnum "_.:|-")) "]")))))
+                       (opt (and "[" (opt (group-n 4 digit)) "]"))
+                       (opt (and "[" (opt (group-n 5 digit)) "]"))
+                       (opt (and "[" (opt (group-n 6 (any alnum "_.:|-"))) "]")))))
+         ;; title wildcard regexp
          (t-rx
           (rx (group-n 1
                        (or "%t" (group-n 2 "%T"))
@@ -138,85 +185,131 @@ the above wildcards.  It has a variable entry bound which is the current bibtex 
                        (opt (and "[" (opt (group-n 4 digit)) "]"))
                        (opt (and "[" (opt (group-n 5 digit)) "]"))
                        (opt (and "[" (opt (group-n 6 (any alnum "_.:|-"))) "]")))))
-         (f-rx (rx (group-n 1 "%f"
-                            (opt (and "[" (group-n 2 digit) "]")))))
-         (F-rx
-          (rx (group-n 1 "%F"
-                       (and "{" (group-n 2 (1+ letter)) "}")
-                       (and "[" (group-n 3 digit) "]")
-                       (opt (and "[" (group-n 4 digit) "]"))
-                       (opt (and "[" (group-n 5 (any alnum "_.:|-")) "]")))))
+         ;; any field wildcard regexp
+         (f-rx
+          (rx (group-n 1
+                       (or "%f" (group-n 2 "%F"))
+                       (and "{" (group-n 3 (1+ letter)) "}")
+                       (opt (and "[" (opt (group-n 4 digit)) "]"))
+                       (opt (and "[" (opt (group-n 5 digit)) "]"))
+                       (opt (and "[" (opt (group-n 6 (any alnum "_.:|-"))) "]")))))
+         ;; year wildcard regexp
+         (y-rx (rx (group-n 1 "%y" (opt (group-n 2 "*")))))
+         ;; page wildcard regexp
+         (p-rx
+          (rx (group-n 1 "%p"
+                       (opt (group-n 2 "*"))
+                       (opt (and "[" (group-n 3 (any alnum "_.:|-")) "]")))))
+         ;; elisp expression wildcard regexp
          (e-rx (rx (group-n 1 "%e"
                             "{" (group-n 2 "(" (1+ ascii) ")") "}"))))
-    ;; Evaluating sexps should go the first because they can produce
+    ;; Evaluating elisp expression should go the first because it can produce
     ;; additional wildcards
     (while (string-match e-rx str)
       (setq str (replace-match
-                 (eval (read (match-string 2 str)))
+                 (orb--autokey-evaluate-expression (match-string 2 str) entry)
                  t nil str 1)))
     ;; Handle author wildcards
-    (while (string-match a-rx str)
-      (setq str (replace-match
-                 (orb--autokey-format-field entry
-                     :field "=name="
-                     :capital (match-string 2 str)
-                     :starred (match-string 3 str)
-                     :words
-                     (when (match-string 4 str)
-                       (string-to-number (match-string 4 str)))
-                     :characters
-                     (when (match-string 5 str)
-                       (string-to-number (match-string 5 str)))
-                     :delimiter (match-string 6 str))
-                 t nil str 1)))
+    (let ((author (or (bibtex-completion-get-value "author" entry)
+                      (bibtex-completion-get-value "editor" entry))))
+      (while (string-match a-rx str)
+        (setq str (replace-match
+                   (orb--autokey-format-field nil
+                       :field "=name="
+                       :value author
+                       :capital (match-string 2 str)
+                       :starred (match-string 3 str)
+                       :words (match-string 4 str)
+                       :characters (match-string 5 str)
+                       :delimiter (match-string 6 str))
+                   t nil str 1))))
     ;; Handle title wildcards
-    (while (string-match t-rx str)
+    (let ((title (or (bibtex-completion-get-value "title" entry) "")))
+      (while (string-match t-rx str)
+        (setq str (replace-match
+                   (orb--autokey-format-field nil
+                       :field "title"
+                       :value title
+                       :capital (match-string 2 str)
+                       :starred (match-string 3 str)
+                       :words (match-string 4 str)
+                       :characters (match-string 5 str)
+                       :delimiter (match-string 6 str))
+                   t nil str 1))))
+    ;; Handle custom field wildcards
+    (while (string-match f-rx str)
       (setq str (replace-match
                  (orb--autokey-format-field entry
-                     :field "title"
+                     :field (match-string 3 str)
                      :capital (match-string 2 str)
-                     :starred (match-string 3 str)
-                     :words
-                     (when (match-string 4 str)
-                       (string-to-number (match-string 4 str)))
-                     :characters
-                     (when (match-string 5 str)
-                       (string-to-number (match-string 5 str)))
+                     :words (match-string 4 str)
+                     :characters (match-string 5 str)
                      :delimiter (match-string 6 str))
                  t nil str 1)))
     ;; Handle year wildcards
-    (while (string-match y-rx str)
-      (setq str (replace-match
-                 (format "%s" (bibtex-completion-get-value "date" entry))
-                 t nil str 1)))
+    ;; year should be well-formed: YYYY
+    (let ((year (or (bibtex-completion-get-value "year" entry)
+                    (bibtex-completion-get-value "date" entry)
+                    "YYYY")))
+      (while (string-match y-rx str)
+        (setq str (replace-match
+                   (format "%s" (if (match-string 2 str)
+                                    (substring year 2 4)
+                                  (substring year 0 4)))
+                   t nil str 1))))
     ;; Handle pages wildcards
-    ;; Handle custom field wildcards
-    ;; debug
-    (setq msorg-temp str)))
+    (while (string-match p-rx str)
+      (setq str (replace-match
+                 (orb--autokey-format-field entry
+                     :field (if (match-string 2 str) "pagetotal"
+                              "pages")
+                     :delimiter (match-string 3 str)
+                     :words 1)
+                 t nil str 1)))
+    str))
 
 (defun orb--autokey-format-field (entry &rest specs)
-  "Format field VALUE from BibTeX ENTRY FIELD according to SPECS.
-%f{field}[3][2][-] - 2 first characters of first 3 words in field
-field delimited with -, downcase.  This is."
+  "Format field of a BibTeX ENTRY according to plist SPECS.
+
+Recognized keys:
+==========
+:field       - BibTeX field to use
+:value       - Value of BibTeX field; it will be used
+               instead the value from ENTRY
+:capital     - capitalized version
+:starred     - starred version
+:words       - first optional parameter (number of words)
+:characters  - second optional parameter (number of characters)
+:delimiter   - third optional parameter (delimiter)
+
+All values should be strings.
+
+This function is used internally by `orb-autokey-generate-key'."
   (-let* (((&plist :field field
+                   :value value
                    :capital capital
                    :starred starred
                    :words words
                    :characters chars
                    :delimiter delim) specs)
-          (separator "[ \n\t]")
+          ;; field values will be split into list of words. `separator' is a
+          ;; regexp for word separators: either whitespaces, or at least two
+          ;; dashes, or en dash, or em dash
+          (separator "\\([ \n\t]\\|-[-]+\\|[—–]\\)")
           (delim (or delim ""))
-          value result)
+          result)
     ;; field "=name=" used internally in `orb-autokey-generate-key'
     ;; stands for author or editor
     (if (string= field "=name=")
-        ;; in name fields the "punctuation" character
-        ;; is the word "and"
-        (progn
-          (setq separator "and")
-          (setq value (or (bibtex-completion-get-value "author" entry)
-                          (bibtex-completion-get-value "editor" entry))))
-      (setq value (bibtex-completion-get-value field entry)))
+        ;; in name fields, logical words are full names consisting of several
+        ;; words and containing spaces and punctuation, separated by a logical
+        ;; separator, the word "and"
+        (setq separator "and"
+              value (or value
+                        (bibtex-completion-get-value "author" entry)
+                        (bibtex-completion-get-value "editor" entry)))
+      (setq value (or value
+                      (bibtex-completion-get-value field entry))))
     (when value
       (save-match-data
         ;; split field into words
@@ -235,36 +328,51 @@ field delimited with -, downcase.  This is."
                                           result)))))
         ;; take number of words equal to WORDS if that is set
         ;; or just the first word; also 0 = 1.
-        (if (and words (> words 0))
-            (setq result (if (> words (length result))
+        (if words
+            (setq words (string-to-number words)
+                  result (if (> words (length result))
                              (-take (length result) result)
                            (-take words result) ))
           (setq result (list (car result))))
         ;; only for "=name=" field, i.e. author or editor
         ;; STARRED = include initials
-        ;; NOTE: here we expect name field Doe, J. B.
-        ;; should ideally be able to handle Doe, John M. Longname , Jr
-        (if (and (string= field "=name=")
-                 starred)
-            (setq result (--map (s-replace-regexp "[ ,.\t\n]" "" it)
-                                result))
-          (setq result (--map (s-replace-regexp "\\(.*?\\),.*" "\\1" it)
-                              result)))
+        (when (string= field "=name=")
+          (if starred
+              ;; NOTE: here we expect name field 'Doe, J. B.'
+              ;; should ideally be able to handle 'Doe, John M. Longname, Jr'
+              (setq result (--map (s-replace-regexp "[ ,.\t\n]" "" it)
+                                  result))
+            (setq result (--map (s-replace-regexp "\\(.*?\\),.*" "\\1" it)
+                                result))))
         ;; take at most CHARS number of characters from every word
         (when chars
-          (setq result (--map (substring it 0 (if (< chars (length it))
-                                                  chars
-                                                (length it)))
-                              result)))
+          (setq chars (string-to-number chars)
+                result (--map (substring it 0 (if (< chars (length it))
+                                                        chars
+                                                      (length it)))
+                                    result)))
         ;; almost there: concatenate words, include DELIMiter
         (setq result (mapconcat #'identity result delim))
         ;; CAPITAL = preserve case
         (unless capital
-          (setq result (downcase result)))))
+          (setq result (downcase result))))
+      ;; return result or an empty string
+      (or result ""))))
+
+(defun orb--autokey-evaluate-expression (expr &optional entry)
+  "Evaluate arbitrary elisp EXPR passed as readable string.
+The expression will have value of ENTRY bound to `entry' variable
+at its disposal.  ENTRY should be a BibTeX entry as returned by
+`bibtex-completion-get-entry'.  The result returned should be a
+string or nil."
+  (let ((result (eval `(let ((entry (quote ,(copy-tree entry))))
+                         ,(read expr)))))
+    (unless (or (stringp result)
+                (not result))
+      (user-error "Result: %s, invalid type.  \
+Expression must be string or nil" result))
     (or result "")))
 
-;; debug
-(orb-autokey-generate-key (gethash "paris1995a" msorg-key-hashtable))
 (provide 'orb-core)
 ;;; orb-core.el ends here
 ;; Local Variables:

--- a/orb-core.el
+++ b/orb-core.el
@@ -83,6 +83,188 @@ Returns the path to the note file, or nil if it doesn’t exist."
   (let* ((completions (org-roam--get-ref-path-completions)))
     (plist-get (cdr (assoc citekey completions)) :path)))
 
+;; * Automatic generation of citation keys
+
+(defvar orb-autokey-format)
+;; debug
+(setq orb-autokey-format "%y-%e{(format \"%%y\")}-%a*[2][3][_]-%T[3][2][.]")
+
+(defvar orb-autokey-titlewords-ignore bibtex-autokey-titleword-ignore
+  "Patterns from title that will be ignored during key generation.
+Every element is a regular expression to match parts of the title
+that should be ignored during automatic key generation.  Case
+sensitive.
+
+Default value is set from `bibtex-autokey-titleword-ignore'.")
+
+(defun orb-autokey-generate-key (entry)
+  "Generate citation key from ENTRY according to orb-autokey-format.
+
+%A*[2][5][_] - first two author's last names plus initials delimited with _, retain capitals
+%a*[2][5][_] - first two author's last names plus initials delimited with _, downcase
+
+%y - year xxxx
+%Y - year xx (two last digits)
+%p - first page
+%p[-] first and last page delimited with -
+
+%T*[5][2][:] - first five characters of first 2 words in title delimited with :, retain capitals
+%t*[5][2][:] - first five characters of first 2 words in title delimited with :, downcase
+starred version - ignore words from `orb-autokey
+
+%F{field}[3][2][-] - 2 first characters of first 3 words in field field delimited with -, retain capitals
+%f{field}[3][2][-] - 2 first characters of first 3 words in field field delimited with -, downcase
+
+%e{(expr)} - elisp expression that should return string, possibly with
+the above wildcards.  It has a variable entry bound which is the current bibtex entry."
+  (let* ((case-fold-search nil)
+         (str (copy-seq orb-autokey-format))
+         (a-rx
+          (rx (group-n 1
+                       (or "%a" (group-n 2 "%A"))
+                       (opt (group-n 3 "*"))
+                       (opt (and "[" (group-n 4 digit) "]"))
+                       (opt (and "[" (group-n 5 digit) "]"))
+                       (opt (and "[" (group-n 6 (any alnum "_.:|-")) "]")))))
+         (y-rx (rx (group-n 1 "%y")))
+         (Y-rx (rx (group-n 1 "%Y")))
+         (p-rx
+          (rx (group-n 1 "%p"
+                       (opt (and "[" (group-n 2 (any alnum "_.:|-")) "]")))))
+         (t-rx
+          (rx (group-n 1
+                       (or "%t" (group-n 2 "%T"))
+                       (opt (group-n 3 "*"))
+                       (opt (and "[" (opt (group-n 4 digit)) "]"))
+                       (opt (and "[" (opt (group-n 5 digit)) "]"))
+                       (opt (and "[" (opt (group-n 6 (any alnum "_.:|-"))) "]")))))
+         (f-rx (rx (group-n 1 "%f"
+                            (opt (and "[" (group-n 2 digit) "]")))))
+         (F-rx
+          (rx (group-n 1 "%F"
+                       (and "{" (group-n 2 (1+ letter)) "}")
+                       (and "[" (group-n 3 digit) "]")
+                       (opt (and "[" (group-n 4 digit) "]"))
+                       (opt (and "[" (group-n 5 (any alnum "_.:|-")) "]")))))
+         (e-rx (rx (group-n 1 "%e"
+                            "{" (group-n 2 "(" (1+ ascii) ")") "}"))))
+    ;; Evaluating sexps should go the first because they can produce
+    ;; additional wildcards
+    (while (string-match e-rx str)
+      (setq str (replace-match
+                 (eval (read (match-string 2 str)))
+                 t nil str 1)))
+    ;; Handle author wildcards
+    (while (string-match a-rx str)
+      (setq str (replace-match
+                 (orb--autokey-format-field entry
+                     :field "=name="
+                     :capital (match-string 2 str)
+                     :starred (match-string 3 str)
+                     :words
+                     (when (match-string 4 str)
+                       (string-to-number (match-string 4 str)))
+                     :characters
+                     (when (match-string 5 str)
+                       (string-to-number (match-string 5 str)))
+                     :delimiter (match-string 6 str))
+                 t nil str 1)))
+    ;; Handle title wildcards
+    (while (string-match t-rx str)
+      (setq str (replace-match
+                 (orb--autokey-format-field entry
+                     :field "title"
+                     :capital (match-string 2 str)
+                     :starred (match-string 3 str)
+                     :words
+                     (when (match-string 4 str)
+                       (string-to-number (match-string 4 str)))
+                     :characters
+                     (when (match-string 5 str)
+                       (string-to-number (match-string 5 str)))
+                     :delimiter (match-string 6 str))
+                 t nil str 1)))
+    ;; Handle year wildcards
+    (while (string-match y-rx str)
+      (setq str (replace-match
+                 (format "%s" (bibtex-completion-get-value "date" entry))
+                 t nil str 1)))
+    ;; Handle pages wildcards
+    ;; Handle custom field wildcards
+    ;; debug
+    (setq msorg-temp str)))
+
+(defun orb--autokey-format-field (entry &rest specs)
+  "Format field VALUE from BibTeX ENTRY FIELD according to SPECS.
+%f{field}[3][2][-] - 2 first characters of first 3 words in field
+field delimited with -, downcase.  This is."
+  (-let* (((&plist :field field
+                   :capital capital
+                   :starred starred
+                   :words words
+                   :characters chars
+                   :delimiter delim) specs)
+          (separator "[ \n\t]")
+          (delim (or delim ""))
+          value result)
+    ;; field "=name=" used internally in `orb-autokey-generate-key'
+    ;; stands for author or editor
+    (if (string= field "=name=")
+        ;; in name fields the "punctuation" character
+        ;; is the word "and"
+        (progn
+          (setq separator "and")
+          (setq value (or (bibtex-completion-get-value "author" entry)
+                          (bibtex-completion-get-value "editor" entry))))
+      (setq value (bibtex-completion-get-value field entry)))
+    (when value
+      (save-match-data
+        ;; split field into words
+        (setq result (split-string value separator t "[ ,.;:-]+"))
+        ;; only for title;
+        ;; STARRED = include words from `orb-autokey-titlewords-ignore
+        ;; "default" unstarred version filters the keywords
+        (when (and (string= field "title")
+                   (not starred))
+          (let ((ignore-rx (concat "\\`\\(:?"
+                                   (mapconcat #'identity
+                                              orb-autokey-titlewords-ignore
+                                              "\\|") "\\)\\'")))
+            (setq result (-flatten (--map (if (string-match-p ignore-rx it)
+                                              nil it)
+                                          result)))))
+        ;; take number of words equal to WORDS if that is set
+        ;; or just the first word; also 0 = 1.
+        (if (and words (> words 0))
+            (setq result (if (> words (length result))
+                             (-take (length result) result)
+                           (-take words result) ))
+          (setq result (list (car result))))
+        ;; only for "=name=" field, i.e. author or editor
+        ;; STARRED = include initials
+        ;; NOTE: here we expect name field Doe, J. B.
+        ;; should ideally be able to handle Doe, John M. Longname , Jr
+        (if (and (string= field "=name=")
+                 starred)
+            (setq result (--map (s-replace-regexp "[ ,.\t\n]" "" it)
+                                result))
+          (setq result (--map (s-replace-regexp "\\(.*?\\),.*" "\\1" it)
+                              result)))
+        ;; take at most CHARS number of characters from every word
+        (when chars
+          (setq result (--map (substring it 0 (if (< chars (length it))
+                                                  chars
+                                                (length it)))
+                              result)))
+        ;; almost there: concatenate words, include DELIMiter
+        (setq result (mapconcat #'identity result delim))
+        ;; CAPITAL = preserve case
+        (unless capital
+          (setq result (downcase result)))))
+    (or result "")))
+
+;; debug
+(orb-autokey-generate-key (gethash "paris1995a" msorg-key-hashtable))
 (provide 'orb-core)
 ;;; orb-core.el ends here
 ;; Local Variables:

--- a/orb-core.el
+++ b/orb-core.el
@@ -47,6 +47,7 @@
 (require 'bibtex-completion)
 
 (require 'orb-utils)
+(require 'orb-compat)
 
 (eval-when-compile
   (require 'rx))
@@ -316,7 +317,7 @@ This function is used internally by `orb-autokey-generate-key'."
                         (bibtex-completion-get-value "editor" entry)))
       (setq value (or value
                       (bibtex-completion-get-value field entry))))
-    (when value
+    (when (and value (> (length value) 0))
       (save-match-data
         ;; split field into words
         (setq result (split-string value separator t "[ ,.;:-]+"))
@@ -354,16 +355,16 @@ This function is used internally by `orb-autokey-generate-key'."
         (when chars
           (setq chars (string-to-number chars)
                 result (--map (substring it 0 (if (< chars (length it))
-                                                        chars
-                                                      (length it)))
-                                    result)))
+                                                  chars
+                                                (length it)))
+                              result)))
         ;; almost there: concatenate words, include DELIMiter
         (setq result (mapconcat #'identity result delim))
         ;; CAPITAL = preserve case
         (unless capital
-          (setq result (downcase result))))
-      ;; return result or an empty string
-      (or result ""))))
+          (setq result (downcase result)))))
+    ;; return result or an empty string
+    (or result "")))
 
 (defun orb--autokey-evaluate-expression (expr &optional entry)
   "Evaluate arbitrary elisp EXPR passed as readable string.

--- a/orb-core.el
+++ b/orb-core.el
@@ -207,7 +207,8 @@ instead of `orb-autokey-format'."
     ;; additional wildcards
     (while (string-match e-rx str)
       (setq str (replace-match
-                 (orb--autokey-evaluate-expression (match-string 2 str) entry)
+                 (save-match-data
+                   (orb--autokey-evaluate-expression (match-string 2 str) entry))
                  t nil str 1)))
     ;; Handle author wildcards
     (let ((author (or (bibtex-completion-get-value "author" entry)

--- a/orb-core.el
+++ b/orb-core.el
@@ -48,6 +48,10 @@
 
 (require 'orb-utils)
 
+(eval-when-compile
+  (require 'rx))
+
+
 ;; * Customize groups (global)
 ;; All modules should put their `defgroup' definitions here
 
@@ -163,6 +167,7 @@ Default value is set from `bibtex-autokey-titleword-ignore'."
   :type '(repeat :tag "Regular expression" regexp)
   :group 'org-roam-bibtex)
 
+;;;###autoload
 (defun orb-autokey-generate-key (entry &optional control-string)
   "Generate citation key from ENTRY according to `orb-autokey-format'.
 Return a string.  If optional CONTROL-STRING is non-nil, use it


### PR DESCRIPTION
This branch adds a mechanism for automatic generation of citation keys. It is currently primarily intended for PDF Scrapper #44. But the functionality is fairly general and extendable, so it is in the `orb-core.el`. 

It is not ready yet for merging.