### PR TITLE
Orb-publish development branch

### DIFF
--- a/orb-publish.el
+++ b/orb-publish.el
@@ -1,0 +1,43 @@
+;;; orb-publish.el --- Org Roam Bibtex: Publishing -*- coding: utf-8; lexical-binding: t -*-
+
+;; Copyright © 2020 Mykhailo Shevchuk <mail@mshevchuk.com>
+;; Copyright © 2020 Leo Vivier <leo.vivier+dev@gmail.com>
+
+;; Author: Leo Vivier <leo.vivier+dev@gmail.com>
+;; 	Mykhailo Shevchuk <mail@mshevchuk.com>
+;; URL: https://github.com/org-roam/org-roam-bibtex
+;; Keywords: org-mode, roam, convenience, bibtex, helm-bibtex, ivy-bibtex, org-ref
+;; Version: 0.2.3
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+;;
+;; This library provides an interface for convenient publishing of
+;; org-roam notes via `org-publish'.
+;;
+
+;;; Code:
+;; * Library requires
+
+
+(provide 'orb-publish)
+;;; orb-publish.el ends here
+;; Local Variables:
+;; fill-column: 79
+;; End:


### PR DESCRIPTION
This branch will be dedicated to publishing org-roam notes with an emphasis on creating annotated bibliographies. See #19.

Backend:
- `org-publish` and `ox`

Planned features:
1. A mechanism to aggregate notes into one temporary file/buffer which will be published as a single PDF file. It doesn't make much sense to publish every note as a single PDF file. Therefore 2:
2. A LaTeX template and/or an option to use a template for publishing, fine tuned for a nice one-note-per-page layout.
3. A mechanism to filter notes for publishing using subdirectories, org-roam tags, specific BibTeX fields.

Html publishing seems to be more or less useable with out-of-the-box `ox`, see the amazing [Org Roam Server](https://github.com/org-roam/org-roam-server). But we would perhaps like to add some filtering and other `org-roam-bibtex`-specific features.