### PR TITLE
do not require bibtex-completion

### DIFF
--- a/orb-core.el
+++ b/orb-core.el
@@ -1,4 +1,4 @@
-;;; orb-core.el --- Org Roam Bibtex: Core library -*- coding: utf-8; lexical-binding: t -*-
+;;; orb-core.el --- Org Roam BibTeX: Core library -*- coding: utf-8; lexical-binding: t -*-
 
 ;; Copyright © 2020 Mykhailo Shevchuk <mail@mshevchuk.com>
 ;; Copyright © 2020 Leo Vivier <leo.vivier+dev@gmail.com>
@@ -37,16 +37,17 @@
 ;;; Code:
 ;; * Library requires
 ;;
-;; 1. org-roam requires org, org-ref (with many dependencies),
-;; org-element, dash, f, s, emacsql, emacsql-sqlite;
-;; 2. bibtex-completion additionally requires parsebib and biblio;
-;;
-;; So all these libraries are always at our disposal
+;; org-roam requires org,org-element, dash, f, s, emacsql, emacsql-sqlite,
+;; so all these libraries are always at our disposal
 ;;
 (require 'org-roam)
-(require 'bibtex-completion)
 
 (require 'orb-utils)
+
+(declare-function
+ bibtex-completion-get-entry "bibtex-completion" (entry-key))
+(declare-function
+ bibtex-completion-find-pdf (key-or-entry &optional find-additional))
 
 ;; Customize groups
 (defgroup org-roam-bibtex nil

--- a/orb-note-actions.el
+++ b/orb-note-actions.el
@@ -52,6 +52,8 @@
 (declare-function ivy-read "ivy")
 (declare-function defhydra "hydra")
 
+(declare-function org-ref-format-entry "org-ref-bibtex" (key))
+
 ;; * Customize definitions
 
 (defcustom orb-note-actions-frontend 'default

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -73,10 +73,19 @@
   (require 'subr-x)
   (require 'cl-lib))
 
+(defvar bibtex-completion-bibliography)
+(defvar bibtex-completion-find-note-functions)
+(declare-function bibtex-completion-apa-get-value
+                  "bibtex-completion" (field entry &optional default))
+(declare-function bibtex-completion-get-entry
+                  "bibtex-completion" (entry-key))
+
 (declare-function projectile-relevant-open-projects "projectile")
 (declare-function persp-switch "persp-mode")
 (declare-function persp-names "persp-mode")
 
+(defvar org-ref-notes-function)
+(declare-function org-ref-find-bibliography "org-ref-core")
 
 ;; * Customize definitions
 
@@ -221,7 +230,6 @@ extra integration between the two packages.
 
 This is a wrapper function around `orb-edit-notes'
 intended for use with Org-ref."
-  ;; org-roam softly requires org-ref, so do we
   (when (require 'org-ref nil t)
     (let ((bibtex-completion-bibliography (org-ref-find-bibliography)))
       (orb-edit-notes citekey))))
@@ -412,17 +420,19 @@ Otherwise, behave as if called interactively."
   :global t
   (cond (org-roam-bibtex-mode
          (setq org-ref-notes-function 'orb-notes-fn)
-         (add-to-list 'bibtex-completion-find-note-functions
-                      #'orb-find-note-file)
-         (advice-add 'bibtex-completion-edit-notes
-                     :override #'orb-edit-notes-ad))
+         (with-eval-after-load 'bibtex-completion
+           (add-to-list 'bibtex-completion-find-note-functions
+                        #'orb-find-note-file)
+           (advice-add 'bibtex-completion-edit-notes
+                       :override #'orb-edit-notes-ad)))
         (t
          (setq org-ref-notes-function 'org-ref-notes-function-one-file)
-         (setq bibtex-completion-find-note-functions
-               (delq #'orb-find-note-file
-                     bibtex-completion-find-note-functions))
-         (advice-remove 'bibtex-completion-edit-notes
-                        #'orb-edit-notes-ad))))
+         (with-eval-after-load 'bibtex-completion
+           (setq bibtex-completion-find-note-functions
+                 (delq #'orb-find-note-file
+                       bibtex-completion-find-note-functions))
+           (advice-remove 'bibtex-completion-edit-notes
+                          #'orb-edit-notes-ad)))))
 
 ;;;###autoload
 (defun orb-edit-notes (citekey)


### PR DESCRIPTION
Since `org-roam` as of v1.2.0 does not require `org-ref` upon start-up, we declare the functions used from `org-ref` (we previously relied on `org-roam` requiring `org-ref`).

Also,
https://github.com/hlissner/doom-emacs/pull/2888

Use `declare-function` to declare a couple of `bibtex-completion` functions instead of top-level ` (require 'bibtex-completion)` . 