### PR TITLE
Remove hook based on upstream change

### DIFF
--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -532,8 +532,6 @@ before calling any Org-roam functions."
                      (list (cons 'title title)
                            (cons 'ref citekey-formatted)
                            (cons 'slug (org-roam--title-to-slug citekey)))))
-                (add-hook 'org-capture-after-finalize-hook
-                          #'org-roam-capture--find-file-h)
                 (org-roam-capture--capture))
             (org-roam-find-file title))
         (message "Something went wrong. Check the *Warnings* buffer.")))))

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -532,6 +532,7 @@ before calling any Org-roam functions."
                      (list (cons 'title title)
                            (cons 'ref citekey-formatted)
                            (cons 'slug (org-roam--title-to-slug citekey)))))
+                (setq org-roam-capture-additional-template-props (list :finalize 'find-file))
                 (org-roam-capture--capture))
             (org-roam-find-file title))
         (message "Something went wrong. Check the *Warnings* buffer.")))))


### PR DESCRIPTION
Fixes #86.

Removing the hook seems to do the trick, since we've changed the way we hook onto `org-capture` in org-roam/org-roam/pull/966.