### PR TITLE
Respect user set org-roam-title-to-slug-function

### DIFF
--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -530,7 +530,7 @@ before calling any Org-roam functions."
                     (org-roam-capture--info
                      (list (cons 'title title)
                            (cons 'ref citekey-formatted)
-                           (cons 'slug (org-roam--title-to-slug citekey)))))
+                           (cons 'slug (funcall org-roam-title-to-slug-function citekey)))))
                 (setq org-roam-capture-additional-template-props (list :finalize 'find-file))
                 (org-roam-capture--capture))
             (org-roam-find-file title))


### PR DESCRIPTION
Org-roam allows its users to set a custom function to convert a title to the filename slug.

See https://github.com/org-roam/org-roam/pull/833.