### PR TITLE
improve orb-process-file-field

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,12 +398,16 @@ fullcite:%\1
 You can also use a function to generate the template on the fly, see
 `org-capture-templates` for details.
 
-#### Org-noter integration `%(orb-process-file-field \"${=key=}\")`
+#### Org-noter integration.  Special treatment of the "file" keyword
 
-The convenience function `orb-process-file-field` allows to find
-documents associated with the BibTeX entry.  It is intended to be used
-in a template via a `%`-escape form for sexp (`%(sexp)`).  See
-`org-capture-templates` for details.
+If `orb-process-file-keyword` is non-nil, the "file" field will be treated
+specially.  If the field contains only one file name, its value will be used
+for template expansion.  If it contains several file names, the user will be
+prompted to choose one.  The file names can be filtered based on their
+extensions by setting the `orb-file-field-extensions` variable, so that only
+those matching the extension or extensions will be considered for retrieval.
+The "file" keyword must be set for preformatting as usual.  Consult the
+docstrings of these variables for additional customization options.
 
 Below shows how this can be used to integrate with
 [org-noter](https://github.com/weirdNox/org-noter) or
@@ -411,7 +415,9 @@ Below shows how this can be used to integrate with
 
 ```el
 (setq orb-preformat-keywords
-   '(("citekey" . "=key=") "title" "url" "file" "author-or-editor" "keywords"))
+      '("citekey" "title" "url" "author-or-editor" "keywords" "file")
+      orb-process-file-field t
+      orb-file-field-extensions "pdf")
 
 (setq orb-templates
       '(("r" "ref" plain (function org-roam-capture--get-point)
@@ -427,7 +433,7 @@ Below shows how this can be used to integrate with
 :Custom_ID: ${citekey}
 :URL: ${url}
 :AUTHOR: ${author-or-editor}
-:NOTER_DOCUMENT: %(orb-process-file-field \"${citekey}\")
+:NOTER_DOCUMENT: ${file}
 :NOTER_PAGE:
 :END:")))
 ```

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -183,6 +183,30 @@ about BibTeX field names."
            :value-type (string :tag "Field")))
   :group 'org-roam-bibtex)
 
+(defcustom orb-process-file-keyword t
+  "Whether to treat the file wildcards specially during template preformatting.
+When this variable is non-nil, \"%^{file}\" and \"${file}\"
+wildcards will be expanded by `org-process-file-field' rather
+than simply replaced with the field value.  This may be useful in
+situations when the file field contans several file names and
+only one file name is desirable for retrieval.  Do this even when
+\"file\" keyword is set for preformatting in `orb-preformat-keywords'.
+
+If this variable is `string', for example \"my-file\", use its
+value as the wildcard keyword instead of the default \"file\"
+keyword.  Thus, it will be possible to get both the raw file
+field value by expanding %^{file} and ${file} wildcards and a
+single file name by expanding %^{my-file} and ${my-file}
+wildcards.
+
+See also `orb-file-field-extensions' for filtering file names
+based on their extension."
+  :group 'org-roam-bibtex
+  :type '(choice
+          (const :tag "Yes" t)
+          (const :tag "No" nil)
+          (string :tag "Custom wildcard keyword")))
+
 (defcustom orb-citekey-format "cite:%s"
   "Format string for the citekey.
 The citekey obtained from Helm-bibtex/Ivy-bibtex/Org-ref
@@ -292,7 +316,7 @@ The special keywords and their replacements are defined in
 TEMPLATE is an element of `org-roam-capture-templates' and ENTRY
 is a BibTeX entry as returned by `bibtex-completion-get-entry'."
   ;; Handle org-roam-capture part
-  (let* ((kwds (->>;; normalize orb-preformat-keywords
+  (let* ((kwds (->> ;; normalize orb-preformat-keywords
                 (if (listp orb-preformat-keywords)
                     orb-preformat-keywords
                   (list orb-preformat-keywords))
@@ -318,7 +342,15 @@ is a BibTeX entry as returned by `bibtex-completion-get-entry'."
          (plst (cdr template))
          ;; regexp for org-capture prompt wildcard
          (rx "\\(%\\^{[[:alnum:]-_]*}\\)")
+         process-file-keyword
          lst)
+    ;; Maybe treat "file" keyword specially
+    (when orb-process-file-keyword
+      (let ((file-keyword (or (and (stringp orb-process-file-keyword)
+                                   orb-process-file-keyword)
+                              "file")))
+        (setq kwds (append (list file-keyword) kwds)
+              process-file-keyword t)))
     ;; First run:
     ;; 1) Make a list of (rplc-s field-value match-position) for the
     ;; second run
@@ -330,10 +362,16 @@ is a BibTeX entry as returned by `bibtex-completion-get-entry'."
              (field-name (or (cdr-safe kwd) kwd))
              ;; get the bibtex field value
              (field-value
-              ;; condition-case to temporary workaround an upstream bug
-              (condition-case nil
-                  (bibtex-completion-apa-get-value field-name entry)
-                (error "")))
+              ;; maybe process file keyword
+              (if process-file-keyword
+                  (prog1
+                      (orb-process-file-field
+                       (bibtex-completion-apa-get-value "=key=" entry))
+                    (setq process-file-keyword nil))
+                ;; condition-case to temporary workaround an upstream bug
+                (condition-case nil
+                    (bibtex-completion-apa-get-value field-name entry)
+                  (error ""))))
              ;; org-capture prompt wildcard
              (rplc-s (concat "%^{" (or keyword "citekey") "}"))
              ;; org-roam-capture prompt wildcard
@@ -342,7 +380,7 @@ is a BibTeX entry as returned by `bibtex-completion-get-entry'."
              (head (plist-get plst :head))
              ;; org-roam-capture :file-name template
              (fl-nm (plist-get plst :file-name))
-             (i 1)                               ; match counter
+             (i 1)                        ; match counter
              pos)
         ;; Search for rplc-s, set flag m if found
         (when tp


### PR DESCRIPTION
- `orb-process-file-field` can filter the retrieved file names based on a particular
extension
- `orb-file-field-extensions` controls which extensions to match
- `orb-process-file-keyword` controls special treatment of %^{file} and
${file} wildcards during the template expansion

Addresses #98.