### PR TITLE
orb-insert first commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,7 @@ add this after `org-roam/init-org-roam`:
 (defun org-roam/init-org-roam-bibtex ()
   (use-package org-roam-bibtex
     :after org-roam
-    :hook (org-roam-mode . org-roam-bibtex-mode)
-    :bind (:map org-mode-map
-          (("C-c n a" . orb-note-actions)))))
+    :hook (org-roam-mode . org-roam-bibtex-mode))
 ```
 
 ### Doom Emacs
@@ -193,17 +191,13 @@ sexps in your
 ;; If you installed via MELPA
 (use-package org-roam-bibtex
   :after org-roam
-  :hook (org-roam-mode . org-roam-bibtex-mode)
-  :bind (:map org-mode-map
-         (("C-c n a" . orb-note-actions))))
+  :hook (org-roam-mode . org-roam-bibtex-mode))
 
 ;; If you cloned the repository
 (use-package org-roam-bibtex
   :after org-roam
   :load-path "~/projects/org-roam-bibtex/" ;Modify with your own path
-  :hook (org-roam-mode . org-roam-bibtex-mode)
-  :bind (:map org-mode-map
-         (("C-c n a" . orb-note-actions))))
+  :hook (org-roam-mode . org-roam-bibtex-mode))
 ```
 
 ### Without `use-package`
@@ -235,16 +229,12 @@ To revert those actions to their defaults, disable
 
 ### Commands
 
-#### `orb-find-non-ref-file`
+#### `orb-insert` (`C-c n i`)
 
-Similar to `org-roam-find-file`, but it excludes your bibliographical
-notes from the completion-candidates.  This is useful if you have a
-lot of them and do not want to clutter up your other notes.
-
-#### `orb-insert-non-ref`
-
-Similar to `org-roam-insert`, but it excludes your bibliographical
-notes from the completion-list.
+Select a bibliography entry and insert a link to a note associated with it.  If
+the note does not exist yet, create it.  Similar to `org-roam-insert`, if a
+region is selected, it becomes the link description.  Check also [orb-insert
+configuration](#orb-insert-configuration) for a few configuration options.
 
 #### `orb-note-actions`
 
@@ -253,6 +243,19 @@ in note's context.  These commands are run with the note's BibTeX key
 as an argument. The key is taken from the `#+ROAM_KEY:` file property.
 See section [ORB Note Actions](#orb-note-actions-section) for
 details.
+
+#### `orb-find-non-ref-file`
+
+Similar to `org-roam-find-file`, but it excludes your bibliographical
+notes from the completion-candidates.  This is useful if you have a
+lot of them and do not want to clutter up your other notes.
+Default keybinding `C-c n C-f`.
+
+#### `orb-insert-non-ref`
+
+Similar to `org-roam-insert`, but it excludes your bibliographical
+notes from the completion-list.
+Default keybinding `C-c n C-i`.
 
 Configuration
 ---------------
@@ -369,7 +372,30 @@ following BibTeX fields: "citekey", "date", "type", "pdf?", "note?",
 Consult the [`helm-bibtex`](https://github.com/tmalsburg/helm-bibtex)
 package for additional information about BibTeX field names.
 
-#### Handling long templates
+#### `orb-insert` configuration
+##### `orb-insert-frontend`
+
+Frontend to use with `orb-insert`.  Supported frontends are `helm-bibtex`,
+`ivy-bibtex`, and `generic` (`orb-insert-generic`)
+
+##### `orb-insert-link-description`
+
+What piece of information should be used as the link description:
+
+* `title`    - entry's title
+* `citekey`  - entry's citation key
+* `citation` - insert Org-ref citation (default "cite:") instead of a file link.
+
+##### `orb-insert-generic-candidates-format`
+
+How the selection candidates should be presented when using `generic` frontend:
+
+* `key`   - only citation keys.  Fast and pretty, but too little contextual information
+* `entry` - formatted entry.  More information, but not particluarly
+pretty. Consider using `helm-bibtex` or `ivy-bibtex` instead.
+
+#### Tips and tricks
+##### Handling long templates
 
 Long templates can be placed in a separate file, with template
 expansion of BibTeX fields working as usual:
@@ -398,7 +424,7 @@ fullcite:%\1
 You can also use a function to generate the template on the fly, see
 `org-capture-templates` for details.
 
-#### Org-noter integration.  Special treatment of the "file" keyword
+##### Org-noter integration.  Special treatment of the "file" keyword
 
 If `orb-process-file-keyword` is non-nil, the "file" field will be treated
 specially.  If the field contains only one file name, its value will be used

--- a/README.md
+++ b/README.md
@@ -386,6 +386,10 @@ What piece of information should be used as the link description:
 * `citekey`  - entry's citation key
 * `citation` - insert Org-ref citation (default "cite:") instead of a file link.
 
+##### `orb-insert-follow-link`
+
+Whether to follow a newly created link.
+
 ##### `orb-insert-generic-candidates-format`
 
 How the selection candidates should be presented when using `generic` frontend:

--- a/orb-core.el
+++ b/orb-core.el
@@ -85,7 +85,32 @@
   :group 'org-roam-bibtex
   :prefix "orb-autokey-")
 
-;; Various utility functions
+;; * Various utility functions
+;; ** Messaging
+
+(defun orb-warning (warning &optional citekey)
+  "Display a WARNING message.  Return nil.
+Include CITEKEY if it is non-nil."
+  (display-warning
+   :warning (concat "ORB :" (when citekey (format "%s :" citekey)) warning))
+  nil)
+
+;; ** orb-plist
+
+(defvar orb-plist nil
+  "Communication channel for `orb-edit-notes' and related functions.")
+
+(defun orb-plist-put (&rest props)
+  "Add properties PROPS to `orb-plist'.
+Returns the new plist."
+  (while props
+    (setq orb-plist (plist-put orb-plist (pop props) (pop props)))))
+
+(defun orb-plist-get (prop)
+  "Get PROP from `orb-plist'."
+  (plist-get orb-plist prop))
+
+;; ** File field
 
 (defcustom orb-file-field-extensions '("pdf")
   "Extensions of file names to keep when retrieving values from the file field.
@@ -136,7 +161,7 @@ Returns the path to the note file, or nil if it doesn’t exist."
   (let* ((completions (org-roam--get-ref-path-completions)))
     (plist-get (cdr (assoc citekey completions)) :path)))
 
-;; * Automatic generation of citation keys
+;; ** Automatic generation of citation keys
 
 (defcustom orb-autokey-format "%a%y%T[4][1]"
   "Format string for automatically generated citation keys.

--- a/orb-core.el
+++ b/orb-core.el
@@ -116,6 +116,14 @@ Returns the new plist."
     (dolist (keyword keywords)
       (orb-plist-put keyword nil))))
 
+(defmacro with-orb-cleanup (&rest body)
+  "Execute BODY calling `orb-cleanup' as its last form.
+Return the result of executing BODY."
+  (declare (indent 0) (debug t))
+  `(prog1
+       ,@body
+     (orb-cleanup)))
+
 ;; ** File field
 
 (defcustom orb-file-field-extensions '("pdf")

--- a/orb-core.el
+++ b/orb-core.el
@@ -110,6 +110,12 @@ Returns the new plist."
   "Get PROP from `orb-plist'."
   (plist-get orb-plist prop))
 
+(defun orb-cleanup ()
+  "Clean up `orb-plist'."
+  (let ((keywords (-filter #'keywordp orb-plist)))
+    (dolist (keyword keywords)
+      (orb-plist-put keyword nil))))
+
 ;; ** File field
 
 (defcustom orb-file-field-extensions '("pdf")

--- a/orb-utils.el
+++ b/orb-utils.el
@@ -56,7 +56,7 @@ Return result of evaluating the BODY."
      (message "%s...done" ,message)))
 
 ;; * Functions
-
+;; ** Various functions
 (defun orb--unformat-citekey (citekey)
   "Remove format from CITEKEY.
 Format is `orb-citekey-format'."
@@ -183,6 +183,24 @@ the value of `orb--temp-dir'."
 (add-hook 'kill-emacs-hook 'orb--remove-temp-dir)
 
 ;;; End of code adopted from ob-core.el
+
+;; ** Document properties
+
+(defun orb-get-buffer-keyword (keyword &optional buffer)
+  "Return the value of Org-mode KEYWORD in-buffer directive.
+The KEYWORD should be given as a string without \"#+\", e.g. \"title\".
+
+If optional BUFFER is non-nil, return the value from that buffer
+instead of `current-buffer'."
+  ;; NOTE: does not work with `org-element-multiple-keywords' keywords
+  ;; if that will somewhen be required, `org-element' should be used.
+  (with-current-buffer (or buffer (current-buffer))
+    (let ((case-fold-search t))
+      (save-excursion
+        (goto-char (point-min))
+        (re-search-forward
+         (format "^[ 	]*#\\+%s:[ 	]*\\(.*\\)$" keyword) nil t)
+        (match-string-no-properties 1)))))
 
 (provide 'orb-utils)
 ;;; orb-utils.el ends here


### PR DESCRIPTION
New command `orb-insert`: similar to `org-roam-insert` but for BibTeX notes.

This commit also adds a functionality to ease managing of `org-capture` hooks when calling `orb-edit-notes`.  This is now only used to support `orb-insert` but the functionality is appropriate for general use. Similarly, `orb-plist` and getter and setter functions have been added, which may be used anywhere else within `org-roam-bibtex`; and a few other utilities.

<details>
<summary>New functionality</summary>

#### New user interface functions:
- orb-insert

#### New customization options:
- orb-insert-frontend
- orb-insert-link-description
- orb-insert-generic-candidates-format
- orb-edit-notes-note-exists-hook

#### New API functions/macros/variables
- orb-insert-edit-notes
- orb-insert-generic
- orb-register-hook-function
- orb-do-hook-functions
- orb-call-hook-function
- orb-cleanup-hooks
- orb-get-buffer-keyword
- orb-plist
- orb-plist-put
- orb-plist-get
- orb-warning

#### New helper functions/variables
- helm-source-orb-insert
- orb-insert--make-helm-source
- orb-insert--ivy-actions
- orb-insert--link
- orb-insert--link-h
- orb-insert--get-from-db
- orb-insert-lowercase

#### Changed functions:
- orb-edit-notes
</details