### PR TITLE
bump to version 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,33 @@ Well, at least we try!
 
 ## [Unreleased]
 
-## [0.3.1] - 2020-05-10
+## [0.4.0] - 2020-11-07
+### Added
+- `orb-insert` user command to insert links to bibliography notes.  If a note does
+  not exist, create it.
+
+- user options associated with `orb-insert`: `orb-insert-frontend`,
+  `orb-insert-follow-link`, `orb-insert-link-description`,
+  `orb-insert-generic-candidates-format`.
+
+- user option `orb-use-as-slug` to allow for specifying what should be used to
+  expand the ${slug} keyword in templates.
+
+- Default keybindings for `orb-insert`, `orb-insert-non-ref`,
+  `orb-find-file-non-ref`, `orb-note-actions`.
+
+### Changed
+- Internals of `orb-edit-notes`.  The original function was split into two.
+  Template pre-selection happens in `orb--edit-notes`, not in `org-capture`,
+  which obviates the need to pre-format all the templates.
+
+### Fixed
+- Fix typo in `orb--autokey-format-field` leading to the function's incorrect
+  behaviour in some cases.
+- Fix behaviour `orb-edit-notes` throwing an error when the BibTeX field "file"
+  was not present.
+
+## [0.3.1] - 2020-10-05
 ### Added
 - Smart ${file} and %^{file} wildcards 
   If `orb-process-file-keyword` is non nil, process these wildcards with
@@ -36,7 +62,7 @@ Well, at least we try!
 - Broken link to Spacemacs instructions
 - Ensure Anystyle receives absolute file paths
 
-## [0.3.0] - 2020-29-07
+## [0.3.0] - 2020-07-29
 ### Added
 - Feature: ORB PDF Scrapper
 
@@ -156,7 +182,8 @@ Well, at least we try!
 [org-roam]: https://github.com/jethrokuan/org-roam
 [helm-bibtex/bibtex-completion]: https://github.com/tmalsburg/helm-bibtex
 
-[Unreleased]: https://github.com/org-roam/org-roam-bibtex/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/org-roam/org-roam-bibtex/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/org-roam/org-roam-bibtex/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/org-roam/org-roam-bibtex/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/org-roam/org-roam-bibtex/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/org-roam/org-roam-bibtex/compare/v0.2.2...v0.2.3

--- a/README.md
+++ b/README.md
@@ -206,13 +206,11 @@ sexps in your
 ;; If you installed via MELPA
 (require 'org-roam-bibtex)
 (add-hook 'after-init-hook #'org-roam-bibtex-mode)
-(define-key org-roam-bibtex-mode-map (kbd "C-c n a") #'orb-note-actions)
 
 ;; If you cloned the repository
 (add-to-list 'load-path "~/projects/org-roam-bibtex/") ;Modify with your own path
 (require 'org-roam-bibtex)
 (add-hook 'after-init-hook #'org-roam-bibtex-mode)
-(define-key org-roam-bibtex-mode-map (kbd "C-c n a") #'orb-note-actions)
 ```
 
 Usage
@@ -229,14 +227,14 @@ To revert those actions to their defaults, disable
 
 ### Commands
 
-#### `orb-insert` (`C-c n i`)
+#### `orb-insert` (`C-c ) i`)
 
 Select a bibliography entry and insert a link to a note associated with it.  If
 the note does not exist yet, create it.  Similar to `org-roam-insert`, if a
 region is selected, it becomes the link description.  Check also [orb-insert
 configuration](#orb-insert-configuration) for a few configuration options.
 
-#### `orb-note-actions`
+#### `orb-note-actions` (`C-c ) a`)
 
 Type `M-x orb-note-actions` to easily access additional commands useful
 in note's context.  These commands are run with the note's BibTeX key
@@ -249,13 +247,13 @@ details.
 Similar to `org-roam-find-file`, but it excludes your bibliographical
 notes from the completion-candidates.  This is useful if you have a
 lot of them and do not want to clutter up your other notes.
-Default keybinding `C-c n C-f`.
+Default keybinding `C-c ) C-f`.
 
 #### `orb-insert-non-ref`
 
 Similar to `org-roam-insert`, but it excludes your bibliographical
 notes from the completion-list.
-Default keybinding `C-c n C-i`.
+Default keybinding `C-c ) C-i`.
 
 Configuration
 ---------------

--- a/orb-anystyle.el
+++ b/orb-anystyle.el
@@ -1,4 +1,4 @@
-;;; orb-anystyle.el --- Orb Roam BibTeX: Elisp interface to anystyle  -*- coding: utf-8; lexical-binding: t -*-
+;;; orb-anystyle.el --- Orb Roam BibTeX: Elisp interface to Anystyle  -*- lexical-binding: t -*-
 
 ;; Copyright © 2020 Mykhailo Shevchuk <mail@mshevchuk.com>
 ;; Copyright © 2020 Leo Vivier <leo.vivier+dev@gmail.com>
@@ -6,8 +6,6 @@
 ;; Author: Mykhailo Shevchuk <mail@mshevchuk.com>
 ;;         Leo Vivier <leo.vivier+dev@gmail.com>
 ;; URL: https://github.com/org-roam/org-roam-bibtex
-;; Keywords: org-mode, roam, convenience, bibtex, helm-bibtex, ivy-bibtex, org-ref
-;; Verstion 0.3.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -396,5 +394,6 @@ using the default one" pmodel)
 (provide 'orb-anystyle)
 ;;; orb-anystyle.el ends here
 ;; Local Variables:
+;; coding: utf-8
 ;; fill-column: 79
 ;; End:

--- a/orb-compat.el
+++ b/orb-compat.el
@@ -1,4 +1,4 @@
-;;; org-roam-bibtex-compat.el --- Org Roam BibTeX: Obsolete definitions -*- coding: utf-8; lexical-binding: t -*-
+;;; org-roam-bibtex-compat.el --- Org Roam BibTeX: obsolete definitions -*- lexical-binding: t -*-
 
 ;; Copyright © 2020 Mykhailo Shevchuk <mail@mshevchuk.com>
 ;; Copyright © 2020 Leo Vivier <leo.vivier+dev@gmail.com>
@@ -6,8 +6,6 @@
 ;; Author: Leo Vivier <leo.vivier+dev@gmail.com>
 ;; 	Mykhailo Shevchuk <mail@mshevchuk.com>
 ;; URL: https://github.com/org-roam/org-roam-bibtex
-;; Keywords: org-mode, roam, convenience, bibtex, helm-bibtex, ivy-bibtex, org-ref
-;; Verstion 0.3.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -60,5 +58,6 @@
 (provide 'orb-compat)
 ;;; orb-compat.el ends here
 ;; Local Variables:
+;; coding: utf-8
 ;; fill-column: 79
 ;; End:

--- a/orb-core.el
+++ b/orb-core.el
@@ -1,4 +1,4 @@
-;;; orb-core.el --- Org Roam BibTeX: Core library -*- coding: utf-8; lexical-binding: t -*-
+;;; orb-core.el --- Org Roam BibTeX: core library -*- lexical-binding: t -*-
 
 ;; Copyright © 2020 Mykhailo Shevchuk <mail@mshevchuk.com>
 ;; Copyright © 2020 Leo Vivier <leo.vivier+dev@gmail.com>
@@ -6,8 +6,6 @@
 ;; Author: Mykhailo Shevchuk <mail@mshevchuk.com>
 ;;         Leo Vivier <leo.vivier+dev@gmail.com>
 ;; URL: https://github.com/org-roam/org-roam-bibtex
-;; Keywords: org-mode, roam, convenience, bibtex, helm-bibtex, ivy-bibtex, org-ref
-;; Verstion 0.3.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -494,5 +492,6 @@ Expression must be string or nil" result))
 (provide 'orb-core)
 ;;; orb-core.el ends here
 ;; Local Variables:
+;; coding: utf-8
 ;; fill-column: 79
 ;; End:

--- a/orb-note-actions.el
+++ b/orb-note-actions.el
@@ -1,4 +1,4 @@
-;;; orb-note-actions.el --- Org Roam Bibtex: Note actions -*- coding: utf-8; lexical-binding: t -*-
+;;; orb-note-actions.el --- Org Roam Bibtex: note actions -*- lexical-binding: t -*-
 
 ;; Copyright © 2020 Mykhailo Shevchuk <mail@mshevchuk.com>
 ;; Copyright © 2020 Leo Vivier <leo.vivier+dev@gmail.com>
@@ -6,8 +6,6 @@
 ;; Author: Leo Vivier <leo.vivier+dev@gmail.com>
 ;; 	Mykhailo Shevchuk <mail@mshevchuk.com>
 ;; URL: https://github.com/org-roam/org-roam-bibtex
-;; Keywords: org-mode, roam, convenience, bibtex, helm-bibtex, ivy-bibtex, org-ref
-;; Verstion 0.3.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -259,5 +257,6 @@ user actions can be set in `orb-note-actions-user'."
 (provide 'orb-note-actions)
 ;;; orb-note-actions.el ends here
 ;; Local Variables:
+;; coding: utf-8
 ;; fill-column: 79
 ;; End:

--- a/orb-pdf-scrapper.el
+++ b/orb-pdf-scrapper.el
@@ -1,4 +1,4 @@
-;;; orb-pdf-scrapper.el --- Orb Roam BibTeX: PDF reference scrapper -*- coding: utf-8; lexical-binding: t -*-
+;;; orb-pdf-scrapper.el --- Orb Roam BibTeX: PDF reference scrapper -*- lexical-binding: t -*-
 
 ;; Copyright © 2020 Mykhailo Shevchuk <mail@mshevchuk.com>
 ;; Copyright © 2020 Leo Vivier <leo.vivier+dev@gmail.com>
@@ -6,8 +6,6 @@
 ;; Author: Mykhailo Shevchuk <mail@mshevchuk.com>
 ;;         Leo Vivier <leo.vivier+dev@gmail.com>
 ;; URL: https://github.com/org-roam/org-roam-bibtex
-;; Keywords: org-mode, roam, convenience, bibtex, helm-bibtex, ivy-bibtex, org-ref
-;; Verstion 0.3.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -1142,5 +1140,6 @@ KEY is note's citation key."
 (provide 'orb-pdf-scrapper)
 ;;; orb-pdf-scrapper.el ends here
 ;; Local Variables:
+;; coding: utf-8
 ;; fill-column: 79
 ;; End:

--- a/orb-utils.el
+++ b/orb-utils.el
@@ -1,4 +1,4 @@
-;;; orb-utils.el --- Org Roam BibTeX: Utility macros and functions -*- coding: utf-8; lexical-binding: t -*-
+;;; orb-utils.el --- Org Roam BibTeX: utility macros and functions -*- lexical-binding: t -*-
 
 ;; Copyright © 2020 Mykhailo Shevchuk <mail@mshevchuk.com>
 ;; Copyright © 2020 Leo Vivier <leo.vivier+dev@gmail.com>
@@ -6,8 +6,6 @@
 ;; Author: Mykhailo Shevchuk <mail@mshevchuk.com>
 ;;         Leo Vivier <leo.vivier+dev@gmail.com>
 ;; URL: https://github.com/org-roam/org-roam-bibtex
-;; Keywords: org-mode, roam, convenience, bibtex, helm-bibtex, ivy-bibtex, org-ref
-;; Verstion 0.3.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -205,5 +203,6 @@ instead of `current-buffer'."
 (provide 'orb-utils)
 ;;; orb-utils.el ends here
 ;; Local Variables:
+;; coding: utf-8
 ;; fill-column: 79
 ;; End:

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -1,4 +1,4 @@
-;;; org-roam-bibtex.el --- Org Roam meets BibTeX -*- coding: utf-8; lexical-binding: t -*-
+;;; org-roam-bibtex.el --- Org Roam meets BibTeX -*- lexical-binding: t -*-
 
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 ;; Copyright © 2020 Mykhailo Shevchuk <mail@mshevchuk.com>
@@ -8,8 +8,8 @@
 ;; 	Mykhailo Shevchuk <mail@mshevchuk.com>
 ;; 	Jethro Kuan <jethrokuan95@gmail.com>
 ;; URL: https://github.com/org-roam/org-roam-bibtex
-;; Keywords: org-mode, roam, convenience, bibtex, helm-bibtex, ivy-bibtex, org-ref
-;; Verstion 0.3.1
+;; Keywords: bib, hypermedia, outlines, wp
+;; Verstion 0.4.0
 ;; Package-Requires: ((emacs "27.1") (org-roam "1.2.2") (bibtex-completion "2.0.0"))
 
 ;; Soft dependencies: projectile, persp-mode, helm, ivy, hydra
@@ -1180,5 +1180,6 @@ details."
 (provide 'org-roam-bibtex)
 ;;; org-roam-bibtex.el ends here
 ;; Local Variables:
+;; coding: utf-8
 ;; fill-column: 79
 ;; End:


### PR DESCRIPTION
- update the version number
- update the Changelog
- update keybindings in the README
- use package keywords from the `finder-by-keyword` list
- remove version numbers and keywords from files other
  than `org-roam-bibtex.el`