### PR TITLE
(int,doc) update license instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,6 @@ few things:
 3. If neither 1. nor 2. resolved your problem, read the following section on
    [how to get help](#orb-help-me).
 
-##### WARNING! 
-
-- **In version 0.2, the `org-roam-bibtex` namespace was renamed to
-  `orb`, except for `org-roam-bibtex-mode` and other definitions that
-  match the `*-mode*` pattern. The existing functions and variables
-  bearing the old prefix will be supported for a while but support
-  will be dropped eventually. All new functions and variables will
-  have the new prefix except those matching the `*-mode*` pattern,
-  which will retain the `org-roam-bibtex` namespace.**
-
 <a name="orb-help-me"></a>HELP ME!!!
 ---------------
 
@@ -371,9 +361,9 @@ Consult the [`helm-bibtex`](https://github.com/tmalsburg/helm-bibtex)
 package for additional information about BibTeX field names.
 
 #### `orb-insert` configuration
-##### `orb-insert-frontend`
+##### `orb-insert-interface`
 
-Frontend to use with `orb-insert`.  Supported frontends are `helm-bibtex`,
+Interface to use with `orb-insert`.  Supported interfaces are `helm-bibtex`,
 `ivy-bibtex`, and `generic` (`orb-insert-generic`)
 
 ##### `orb-insert-link-description`
@@ -390,7 +380,7 @@ Whether to follow a newly created link.
 
 ##### `orb-insert-generic-candidates-format`
 
-How the selection candidates should be presented when using `generic` frontend:
+How the selection candidates should be presented when using `generic` interface:
 
 * `key`   - only citation keys.  Fast and pretty, but too little contextual information
 * `entry` - formatted entry.  More information, but not particluarly
@@ -488,19 +478,19 @@ are left for user customization.
 There is a number of interfaces available for displaying the available
 note actions: `default` (using `completing-read`), `ido`, `ivy`,
 `helm` and `hydra`.  The interface can be set via the
-`orb-note-actions-frontend` user variable.
+`orb-note-actions-interface` user variable.
 
 ``` el
-(setq orb-note-actions-frontend 'hydra)
+(setq orb-note-actions-interface 'hydra)
 ```
 
-Alternatively, `orb-note-actions-frontend` can be set to a custom
+Alternatively, `orb-note-actions-interface` can be set to a custom
 function that will provide completion for available note actions. The
 function must take one argument CITEKEY, which is a list whose `car`
 is the current note's citation key:
 
 ``` el
-(setq orb-note-actions-frontend #'my-orb-note-actions-frontend)
+(setq orb-note-actions-interface #'my-orb-note-actions-interface)
 ```
 
 ``` org
@@ -508,7 +498,7 @@ is the current note's citation key:
 ```
 
 ``` el
-(defun my-orb-note-actions-frontend (citekey)
+(defun my-orb-note-actions-interface (citekey)
   ;;; For the above note, (car citekey) => "Doe2020"
   ...)
 ```

--- a/orb-anystyle.el
+++ b/orb-anystyle.el
@@ -19,10 +19,9 @@
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs; see the file COPYING.  If not, write to the
-;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-;; Boston, MA 02110-1301, USA.
+;; You should have received a copy of the GNU General Public License along with
+;; this program; see the file LICENSE.  If not, visit
+;; <https://www.gnu.org/licenses/>.
 
 ;; N.B. This file contains code snippets adopted from other
 ;; open-source projects. These snippets are explicitly marked as such

--- a/orb-compat.el
+++ b/orb-compat.el
@@ -19,10 +19,9 @@
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs; see the file COPYING.  If not, write to the
-;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-;; Boston, MA 02110-1301, USA.
+;; You should have received a copy of the GNU General Public License along with
+;; this program; see the file LICENSE.  If not, visit
+;; <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;;
@@ -31,29 +30,10 @@
 ;;; Code:
 
 ;; * org-roam-bibtex.el
-(define-obsolete-variable-alias 'org-roam-bibtex-preformat-templates 'orb-preformat-templates "0.2")
-(define-obsolete-variable-alias 'org-roam-bibtex-templates 'orb-templates "0.2")
-(define-obsolete-variable-alias 'org-roam-bibtex-include-citekey-in-titles 'orb-include-citekey-in-titles "0.2" "0.2")
-(define-obsolete-variable-alias 'org-roam-bibtex-preformat-keywords 'orb-preformat-keywords "0.2")
-(define-obsolete-variable-alias 'org-roam-bibtex-citekey-format 'orb-citekey-format "0.2")
-(define-obsolete-variable-alias 'org-roam-bibtex-persp-project 'orb-persp-project "0.2")
-(define-obsolete-variable-alias 'org-roam-bibtex-switch-persp 'orb-switch-persp "0.2")
-
-(define-obsolete-function-alias 'org-roam-bibtex-notes-fn 'orb-notes-fn "0.2")
-(define-obsolete-function-alias 'org-roam-bibtex-edit-notes-ad 'orb-edit-notes-ad "0.2")
-(define-obsolete-function-alias 'org-roam-bibtex-process-file-field 'orb-process-file-field "0.2")
-(define-obsolete-function-alias 'org-roam-bibtex-edit-notes 'orb-edit-notes "0.2")
-(define-obsolete-function-alias 'org-roam-bibtex-find-non-ref-file 'orb-find-non-ref-file "0.2")
-(define-obsolete-function-alias 'org-roam-bibtex-insert-non-ref 'orb-insert-non-ref "0.2")
-
-;; * org-roam-bibtex-note-actions.el
-
-(define-obsolete-variable-alias 'org-roam-bibtex-note-actions-frontend 'orb-note-actions-frontend "0.2")
-(define-obsolete-variable-alias 'org-roam-bibtex-note-actions-extra 'orb-note-actions-extra "0.2")
-(define-obsolete-variable-alias 'org-roam-bibtex-note-actions-user 'orb-note-actions-user "0.2")
-(define-obsolete-variable-alias 'org-roam-bibtex-note-actions-default 'orb-note-actions-default "0.2")
-
-(define-obsolete-function-alias 'org-roam-bibtex-note-actions 'orb-note-actions "0.2")
+(define-obsolete-variable-alias
+  'orb-insert-frontend 'orb-insert-interface "0.5")
+(define-obsolete-variable-alias
+  'orb-note-actions-frontend 'orb-note-actions-interface "0.5")
 
 (provide 'orb-compat)
 ;;; orb-compat.el ends here

--- a/orb-core.el
+++ b/orb-core.el
@@ -19,10 +19,9 @@
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs; see the file COPYING.  If not, write to the
-;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-;; Boston, MA 02110-1301, USA.
+;; You should have received a copy of the GNU General Public License along with
+;; this program; see the file LICENSE.  If not, visit
+;; <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;;

--- a/orb-helm.el
+++ b/orb-helm.el
@@ -19,10 +19,9 @@
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs; see the file COPYING.  If not, write to the
-;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-;; Boston, MA 02110-1301, USA.
+;; You should have received a copy of the GNU General Public License along with
+;; this program; see the file LICENSE.  If not, visit
+;; <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 
@@ -80,7 +79,7 @@
   "Helm source to use with `orb-insert'.
 A copy of `helm-source-bibtex', in which \"Edit notes\" is made
 the first (default) action.  This action calls `helm-orb-insert-edit-notes'.
-Only relevant when `orb-insert-frontend' is `helm-bibtex'.")
+Only relevant when `orb-insert-interface' is `helm-bibtex'.")
 
 (helm-bibtex-helmify-action orb-insert-edit-notes helm-orb-insert-edit-notes)
 

--- a/orb-ivy.el
+++ b/orb-ivy.el
@@ -19,10 +19,9 @@
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs; see the file COPYING.  If not, write to the
-;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-;; Boston, MA 02110-1301, USA.
+;; You should have received a copy of the GNU General Public License along with
+;; this program; see the file LICENSE.  If not, visit
+;; <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 
@@ -76,7 +75,7 @@
 A copy of Ivy-bibtex's alist defining Ivy actions, in which
 \"Edit note & insert a link\" is made first (default) action.
 This action calls `orb-insert-edit-notes'.  Only relevant when
-`orb-insert-frontend' is `ivy-bibtex'.")
+`orb-insert-interface' is `ivy-bibtex'.")
 
 (ivy-bibtex-ivify-action orb-insert-edit-notes ivy-orb-insert-edit-notes)
 

--- a/orb-pdf-scrapper.el
+++ b/orb-pdf-scrapper.el
@@ -19,10 +19,9 @@
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs; see the file COPYING.  If not, write to the
-;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-;; Boston, MA 02110-1301, USA.
+;; You should have received a copy of the GNU General Public License along with
+;; this program; see the file LICENSE.  If not, visit
+;; <https://www.gnu.org/licenses/>.
 
 ;; N.B. This file contains code snippets adopted from other
 ;; open-source projects. These snippets are explicitly marked as such

--- a/orb-utils.el
+++ b/orb-utils.el
@@ -19,10 +19,9 @@
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs; see the file COPYING.  If not, write to the
-;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-;; Boston, MA 02110-1301, USA.
+;; You should have received a copy of the GNU General Public License along with
+;; this program; see the file LICENSE.  If not, visit
+;; <https://www.gnu.org/licenses/>.
 
 ;; N.B. This file contains code snippets adopted from other
 ;; open-source projects. These snippets are explicitly marked as such
@@ -64,9 +63,9 @@ Return result of evaluating the BODY."
        (progn ,@body)
      (message "%s...done" ,message)))
 
-(defmacro orb-note-actions-defun (frontend &rest body)
-  "Return a function definition for FRONTEND.
-Function name takes a form of orb-note-actions--FRONTEND.
+(defmacro orb-note-actions-defun (interface &rest body)
+  "Return a function definition for INTERFACE.
+Function name takes a form of orb-note-actions--INTERFACE.
 A simple docstring is constructed and BODY is injected into a
 `let' form, which has two variables bound, NAME and
 CANDIDATES.  NAME is a string formatted with
@@ -74,14 +73,14 @@ CANDIDATES.  NAME is a string formatted with
 constructed from `orb-note-actions-default',
 `orb-note-actions-extra', and `orb-note-actions-user'."
   (declare (indent 1) (debug (symbolp &rest form)))
-  (let* ((frontend-name (symbol-name frontend))
-         (fun-name (intern (concat "orb-note-actions-" frontend-name))))
+  (let* ((interface-name (symbol-name interface))
+         (fun-name (intern (concat "orb-note-actions-" interface-name))))
     `(defun ,fun-name (citekey)
        ,(format "Provide note actions using %s interface.
-CITEKEY is the citekey." (capitalize frontend-name))
+CITEKEY is the citekey." (capitalize interface-name))
        (let ((name (org-ref-format-entry citekey)) ;; TODO: make a native format function
              (candidates
-              ,(unless (eq frontend 'hydra)
+              ,(unless (eq interface 'hydra)
                  '(append  orb-note-actions-default
                            orb-note-actions-extra
                            orb-note-actions-user))))

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -26,10 +26,9 @@
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs; see the file COPYING.  If not, write to the
-;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-;; Boston, MA 02110-1301, USA.
+;; You should have received a copy of the GNU General Public License along with
+;; this program; see the file LICENSE.  If not, visit
+;; <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;;
@@ -321,8 +320,8 @@ used to store a link to the BibTeX buffer.  See
   :risky t
   :group 'org-roam-bibtex)
 
-(defcustom orb-insert-frontend 'generic
-  "Frontend to use with `orb-insert'.
+(defcustom orb-insert-interface 'generic
+  "Interface frontend to use with `orb-insert'.
 Possible values are the symbols `helm-bibtex', `ivy-bibtex' and
 `generic'.  In the first two cases the respective commands will
 be used, while in the latter case the command
@@ -367,16 +366,16 @@ information."
           (const :tag "No" nil)))
 
 (defcustom orb-insert-generic-candidates-format 'key
-  "Format of selection candidates for `orb-insert' with `generic' frontend.
+  "Format of selection candidates for `orb-insert' with `generic' interface.
 Possible values are `key' and `entry'."
   :group 'org-roam-bibtex
   :type '(choice
           (const key)
           (const entry)))
 
-(defcustom orb-note-actions-frontend 'default
+(defcustom orb-note-actions-interface 'default
   "Interface frontend for `orb-note-actions'.
-Supported values (frontends) are 'default, 'ido, 'hydra, 'ivy and 'helm.
+Supported values (interfaces) are 'default, 'ido, 'hydra, 'ivy and 'helm.
 
 Alternatively, it can be set to a function, in which case the
 function should expect one argument CITEKEY, which is a list
@@ -968,7 +967,7 @@ made by `bibtex-completion-candidates'.
 The appearance of selection candidates is determined by
 `orb-insert-generic-candidates-format'.
 
-This function is not interactive, set `orb-insert-frontend' to
+This function is not interactive, set `orb-insert-interface' to
 `generic' and call `orb-insert' interactively instead.
 
 If ARG is non-nil, rebuild `bibtex-completion-cache'."
@@ -1038,8 +1037,8 @@ newly created note."
 (defun orb-insert (&optional arg)
   "Insert a link to an Org-roam bibliography note.
 If the note does not exist, create it.
-Use candidate selection frontend specified in
-`orb-insert-frontend'.  Available frontends are `helm-bibtex',
+Use candidate selection interface specified in
+`orb-insert-interface'.  Available interfaces are `helm-bibtex',
 `ivy-bibtex' and `orb-insert-generic'.
 
 When using `helm-bibtex' or `ivy-bibtex', the action \"Edit note
@@ -1053,7 +1052,7 @@ inserted, although the session can be resumed later with
 `helm-resulme' or `ivy-resume', respectively, to select the
 \"Edit note & insert a link\" action.
 
-When using `orb-insert-generic' as frontend, a simple list of
+When using `orb-insert-generic' as interface, a simple list of
 available citation keys is presented using `completion-read' and
 after choosing a candidate the appropriate link will be inserted.
 
@@ -1101,13 +1100,13 @@ two or three universal arguments `\\[universal-argument]' are supplied."
                    (or lowercase orb-insert-lowercase))
     (unless org-roam-mode (org-roam-mode +1))
     ;; execution chain:
-    ;; 1. frontend function
+    ;; 1. interface function
     ;; 2. orb-insert-edit-notes
     ;; 3. orb-edit-notes
     ;; 4. orb-insert--link-h
     ;; if the note exists or a new note was created and capture not cancelled
     ;; 5. orb-insert--link
-    (cl-case orb-insert-frontend
+    (cl-case orb-insert-interface
       (helm-bibtex
        (cond
         ((featurep 'helm-bibtex)
@@ -1197,29 +1196,29 @@ details."
           ,@actions)))
     (orb-note-actions-hydra/body)))
 
-(defun orb-note-actions--run (frontend citekey )
-  "Run note actions on CITEKEY with FRONTEND."
-  (let ((fun (intern (concat "orb-note-actions-" (symbol-name frontend)))))
+(defun orb-note-actions--run (interface citekey )
+  "Run note actions on CITEKEY with INTERFACE."
+  (let ((fun (intern (concat "orb-note-actions-" (symbol-name interface)))))
     (if (fboundp fun)
         (funcall fun citekey)
-      (orb-warning "Note actions frontend %s not available" frontend))))
+      (orb-warning "Note actions interface %s not available" interface))))
 
 ;;;###autoload
 (defun orb-note-actions ()
   "Run an interactive prompt to offer note-related actions.
-The prompt frontend can be set in `orb-note-actions-frontend'.
+The prompt interface can be set in `orb-note-actions-interface'.
 In addition to default actions, which are not supposed to be
 modified, there is a number of prefined extra actions
 `orb-note-actions-extra' that can be customized.  Additionally,
 user actions can be set in `orb-note-actions-user'."
   (interactive)
-  (let ((non-default-frontends (list 'hydra 'ido 'ivy 'helm))
+  (let ((non-default-interfaces (list 'hydra 'ido 'ivy 'helm))
         (citekey (cdr (org-roam--extract-ref))))
     (if citekey
-        (cond ((member orb-note-actions-frontend non-default-frontends)
-               (orb-note-actions--run orb-note-actions-frontend citekey))
-              ((functionp orb-note-actions-frontend)
-               (funcall orb-note-actions-frontend citekey))
+        (cond ((member orb-note-actions-interface non-default-interfaces)
+               (orb-note-actions--run orb-note-actions-interface citekey))
+              ((functionp orb-note-actions-interface)
+               (funcall orb-note-actions-interface citekey))
               (t
                (orb-note-actions--run 'default citekey)))
       (user-error "No #+ROAM_KEY found in current buffer"))))


### PR DESCRIPTION
- point users ot gnu.org for a license
- rename orb-insert-frontend into orb-insert-interface,
  orb-note-actions-frontend into orb-note-actions-interface
- make the old fanctions obsolete
- remove old compatibility declarations