### PR TITLE
(fix) orb-notes-cache for orb-find-note-file

### DIFF
--- a/orb-utils.el
+++ b/orb-utils.el
@@ -232,11 +232,24 @@ the value of `orb--temp-dir'."
 ;;;; Document properties
 ;; ============================================================================
 
+(defvar orb-notes-cache nil
+  "Cache of ORB notes.")
+
+(defun orb-make-notes-cache ()
+  "Update ORB notes hash table `orb-notes-cache'."
+  (let* ((db-entries (org-roam--get-ref-path-completions nil "cite"))
+         (size (round (/ (length db-entries) 0.8125))) ;; ht oversize
+         (ht (make-hash-table :test #'equal :size size)))
+    (dolist (entry db-entries)
+      (let* ((key (car entry))
+             (value (plist-get (cdr (assoc key db-entries)) :path)))
+        (puthash key value ht)))
+    (setq orb-notes-cache ht)))
+
 (defun orb-find-note-file (citekey)
   "Find note file associated with CITEKEY.
 Returns the path to the note file, or nil if it doesn’t exist."
-  (let* ((completions (org-roam--get-ref-path-completions)))
-    (plist-get (cdr (assoc citekey completions)) :path)))
+  (gethash citekey orb-notes-cache))
 
 (defun orb-get-buffer-keyword (keyword &optional buffer)
   "Return the value of Org-mode KEYWORD in-buffer directive.

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -1198,6 +1198,10 @@ This function replaces `bibtex-completion-edit-notes'.  Only the
 first key from KEYS will actually be used."
   (orb-edit-notes (car keys)))
 
+(defun orb-bibtex-completion-parse-bibliography-ad (&optional _ht-strings)
+  "Update `orb-notes-cache' before `bibtex-completion-parse-bibliography'."
+  (orb-make-notes-cache))
+
 (defvar org-roam-bibtex-mode-map
   (make-sparse-keymap)
   "Keymap for `org-roam-bibtex-mode'.")
@@ -1225,14 +1229,18 @@ Otherwise, behave as if called interactively."
          (add-to-list 'bibtex-completion-find-note-functions
                       #'orb-find-note-file)
          (advice-add 'bibtex-completion-edit-notes
-                     :override #'orb-edit-notes-ad))
+                     :override #'orb-edit-notes-ad)
+         (advice-add 'bibtex-completion-parse-bibliography
+                     :before #'orb-bibtex-completion-parse-bibliography-ad))
         (t
          (setq org-ref-notes-function 'org-ref-notes-function-one-file)
          (setq bibtex-completion-find-note-functions
                (delq #'orb-find-note-file
                      bibtex-completion-find-note-functions))
          (advice-remove 'bibtex-completion-edit-notes
-                        #'orb-edit-notes-ad))))
+                        #'orb-edit-notes-ad)
+         (advice-remove 'bibtex-completion-parse-bibliography
+                        #'orb-bibtex-completion-parse-bibliography-ad))))
 
 (define-key org-roam-bibtex-mode-map (kbd "C-c ) a") #'orb-note-actions)
 (define-key org-roam-bibtex-mode-map (kbd "C-c ) i") #'orb-insert)


### PR DESCRIPTION
To greatly speed up things when bibtex-completion builds its cache
Fix #156

`orb-find-note-file` now does not have a visible impact on `bibtex-completion-parse-bibliography` (master bib file with ~1800 entries):

1 run with the old function: ~15.5 s
1 run with the fixed function: ~2.9 s
1 run without using `orb-find-note-file`: ~2.9 s
1 run with `orb-find-note-file` + default functions: ~3.1 s

This simple test was used:

```elisp
(benchmark-run 5
  (progn
    (setq orb-notes-cache nil
          bibtex-completion-cache nil)
    (bibtex-completion-candidates)))
```

| fix | value of `bibtex-completion-find-note-functions | total time, s | GC runs | GC time |
| --- | --- | --- | --- | --- |
| no | '(orb-find-note-file) | 77.518197 | 420 | 44.164464 |
|  yes | '(orb-find-note-file) |  14.664627 | 62 | 7.8004900000000035 |
| yes | nil | 14.822348999999999 | 62 | 7.909169999999996 |
| yes | '(orb-find-note-file bibtex-completion-find-note-multiple-files bibtex-completion-find-note-one-file) | 15.358028 | 62 | 8.055791999999997 |


