### PR TITLE
Initialize org-notes-cache lazily on demand

### DIFF
--- a/orb-utils.el
+++ b/orb-utils.el
@@ -249,7 +249,8 @@ the value of `orb--temp-dir'."
 (defun orb-find-note-file (citekey)
   "Find note file associated with CITEKEY.
 Returns the path to the note file, or nil if it doesn’t exist."
-  (gethash citekey orb-notes-cache))
+  (gethash citekey (or orb-notes-cache
+                       (orb-make-notes-cache))))
 
 (defun orb-get-buffer-keyword (keyword &optional buffer)
   "Return the value of Org-mode KEYWORD in-buffer directive.


### PR DESCRIPTION
I've been having problems properly loading `org-roam-bibtex` and `org-ref`; one symptom is that `orb-find-note-file` was
being called before `orb-notes-cache` was initialized, and it seems like a lazy initialization would make
`orb-find-note-file` more robust.