### PR TITLE
abbreviate file path

### DIFF
--- a/orb-core.el
+++ b/orb-core.el
@@ -120,6 +120,14 @@ The name of the file field is determined by
           (string)
           (repeat :tag "List of extensions" (string))))
 
+(defcustom orb-abbreviate-file-name t
+  "Non-nil to abbreviate the file name from bibtex file."
+
+  :group 'org-roam-bibtex
+  :type '(choice
+          (const :tag "Yes" t)
+          (const :tag "No" nil)))
+
 ;;;###autoload
 (defun orb-process-file-field (citekey)
   "Process the 'file' BibTeX field and resolve if there are multiples.
@@ -152,7 +160,10 @@ to enter."
               (completing-read "File to use: " paths))))
 
         (when final-path
-          (abbreviate-file-name final-path)))
+          (if orb-abbreviate-file-name
+            (abbreviate-file-name final-path)
+            final-path)))
+
     ;; ignore any errors that may be thrown by `bibtex-completion-find-pdf'
     ;; don't stop the capture process
     (error nil)))

--- a/orb-core.el
+++ b/orb-core.el
@@ -144,10 +144,15 @@ to enter."
                        (when-let ((extension (file-name-extension it)))
                          (member-ignore-case extension extensions))
                        paths)))
-        (when paths
-          (if (= (length paths) 1)
+
+        (setq final-path
+          (when paths
+            (if (= (length paths) 1)
               (car paths)
-            (completing-read "File to use: " paths))))
+              (completing-read "File to use: " paths))))
+
+        (when final-path
+          (abbreviate-file-name final-path)))
     ;; ignore any errors that may be thrown by `bibtex-completion-find-pdf'
     ;; don't stop the capture process
     (error nil)))


### PR DESCRIPTION
currently org-roam-bibtex will insert the absolute file path as is from bib file.

for eg, it's something like this with my current orb template:
```
:NOTER_DOCUMENT: /Users/emacsbliss/Zotero/storage/SV96UAIW/how-javascript-works-the-mechanics-of-web-push-notifications-290176c5c55d.html
```

However the issue is when I switch to different computer (for eg, company one) where I don't have control with username, then org-noter will break because user name is different even though Zotero is installed on same location (ie. ~/Zotero) on both machine.

I think it would make sense to insert abbreviate file path so it will work on different machines with different username as long as Zotero is under same location relative to user home directory.

With this PR, it will insert this:
```
:NOTER_DOCUMENT: ~/Zotero/storage/SV96UAIW/how-javascript-works-the-mechanics-of-web-push-notifications-290176c5c55d.html
```
