### PR TITLE
(fix) Make org-roam-bibtex-mode buffer-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The package is on [MELPA](https://github.com/melpa/melpa).
     ``` emacs-lisp
     (use-package org-roam-bibtex
       :after org-roam
-      :hook (org-roam-mode . org-roam-bibtex-mode)
+      :hook (org-roam-file-setup . org-roam-bibtex-mode)
       :config
       (require 'org-ref)) ; optional: if Org Ref is not loaded anywhere else, load it here
     ```
@@ -141,7 +141,7 @@ The package is on [MELPA](https://github.com/melpa/melpa).
 
     ``` emacs-lisp
     (require 'org-roam-bibtex)
-    (add-hook 'org-roam-mode-hook #'org-roam-bibtex-mode)
+    (add-hook 'org-roam-file-setup-hook #'org-roam-bibtex-mode)
     (require 'org-ref) ; optional: if Org Ref is not loaded anywhere else, load it here
     ```
 

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -1227,7 +1227,6 @@ Otherwise, behave as if called interactively."
   :keymap  org-roam-bibtex-mode-map
   :group 'org-roam-bibtex
   :require 'orb
-  :global t
   (require 'bibtex-completion)
   (cond (org-roam-bibtex-mode
          (setq org-ref-notes-function 'orb-notes-fn)


### PR DESCRIPTION
Avoids make the keymap active globally, since C-c ) conflicts with
RefTeX, for example.

Update the README to hook into org-roam-file-setup-hook, so
org-roam-bibtex-mode is activated only for org-roam files.