### PR TITLE
fix: (wrong-type-argument stringp nil) when adding a non-bibtex note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,23 @@ Well, at least we try!
 
 ## [Unreleased]
 
+## [0.5.1] - 2021-05-07
+### Added
+- This is the last version of ORB that works with Org-roam v1.  Future releases
+  of ORB starting with v0.6 will work only with Org-roam v2 and will not be
+  backwards compatible with ORB < v0.6.  There will be no deprecation notices
+  on functions and variables!
+- Update README with the above notice.
+- A basic setup for Eldev was added.  No tests yet.
+
 ### Changed
-- Remove keybindigns in `org-roam-bibtex-mode-map`.
+- Default keybindings for ORB commands were removed from `org-roam-bibtex-map`
+  because they were non-essential conflicted with some other minor modes.
+
+### Fixed
+- Added Org-ref to `Package-Requires` declaration.
+- Issue a warning in `orb-process-file-field` instead of ignoring errors
+  silently.
 
 ## [0.5.0] - 2021-03-17
 ### Added
@@ -246,8 +261,9 @@ and fruitful discussions on export, reference grouping and reference numbers!
 [org-roam]: https://github.com/jethrokuan/org-roam
 [helm-bibtex/bibtex-completion]: https://github.com/tmalsburg/helm-bibtex
 
-[Unreleased]: https://github.com/org-roam/org-roam-bibtex/compare/v0.5.0...HEAD
-[0.4.0]: https://github.com/org-roam/org-roam-bibtex/compare/v0.4.0...v0.5.0
+[Unreleased]: https://github.com/org-roam/org-roam-bibtex/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/org-roam/org-roam-bibtex/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/org-roam/org-roam-bibtex/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/org-roam/org-roam-bibtex/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/org-roam/org-roam-bibtex/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/org-roam/org-roam-bibtex/compare/v0.2.3...v0.3.0

--- a/Eldev
+++ b/Eldev
@@ -1,6 +1,7 @@
 ; -*- mode: emacs-lisp; lexical-binding: t; no-byte-compile: t -*-
 
 ;; Autodetermined by `eldev init'.
-(eldev-use-package-archive 'melpa)
+(eldev-use-package-archive 'gnu)
+(eldev-use-package-archive 'melpa-unstable)
 
 (eldev-use-plugin 'autoloads)

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Usage
 
 You can now access your bibliographical notes in `org-roam-directory` with
 `helm-bibtex`/`ivy-bibtex` or by opening `org-ref` links.  ORB modifies the
-behaviour of the above packages to make them use `orb-edit-notes` instead of
+behaviour of the above packages to make them use `orb-edit-note` instead of
 their default note-management commands.  To get their default behaviour back,
 disable `org-roam-bibtex-mode`.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ org-roam-bibtex
 
 <img alt="ORB logo" src="img/logo-r500.png" width="150">
 
+BREAKING NEWS*
+---------------
+
+**Org Roam BibTeX will be upgraded to v0.6 on the upcoming Saturday, *July 3rd,
+2021, 00:00 CEST***, following (or preceding?) the Org-roam upgrade to v2! Once
+again, on **Friday the 2nd of July at 23:00 in London**, and at **6 pm in New York** as
+well as on **Saturday, July 3rd, at 6 am in Hong Kong** and at **7 am in Tokyo**, ORB
+will be upgraded to v0.6, which is uncompatible with the current v0.5.1
+configuration.
+
+\* As in your config will break up
+
 Description
 ---------------
 
@@ -45,11 +57,16 @@ Future releases of ORB starting with v0.6 will work only with Org-roam v2 and
 will not be backwards compatible with ORB < v0.6.  There will be no deprecation
 notices on functions and variables!
 
-The `master` branch will be kept on v0.5.1 for a while. 
-
 The yet unreleased version compatible with Org-roam v2 can be found on the
-`org-roam-v2` branch for testing and early adoption.  It will be eventually
-merged into `master`.
+`org-roam-v2` branch for testing and early adoption.  ~~It will be eventually
+merged into `master`.~~
+
+**Org Roam BibTeX will be upgraded to v0.6 on the upcoming Saturday, July 3rd,
+2021, 00:00 CEST, following (or preceding?) the Org-roam upgrade to v2! Once
+again, on Friday the 2nd of July at 23:00 in London, and at 6 pm in New York as
+well as on Saturday, July 3rd, at 6 am in Hong Kong and at 7 am in Tokyo, ORB
+will be upgraded to v0.6, which is uncompatible with current v0.5.1
+configuration.**
 
 A word of warning 🚧
 ---------------

--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ The package is on [MELPA](https://github.com/melpa/melpa).
     ``` emacs-lisp
     (use-package org-roam-bibtex
       :after org-roam
-      :hook (org-roam-mode . org-roam-bibtex-mode)
       :config
       (require 'org-ref)) ; optional: if Org Ref is not loaded anywhere else, load it here
     ```
@@ -154,9 +153,8 @@ The package is on [MELPA](https://github.com/melpa/melpa).
     b) Alternatively, require the package if you don't use `use-package`:
 
     ``` emacs-lisp
-    (require 'org-roam-bibtex)
-    (add-hook 'org-roam-mode-hook #'org-roam-bibtex-mode)
     (require 'org-ref) ; optional: if Org Ref is not loaded anywhere else, load it here
+    (require 'org-roam-bibtex)
     ```
 
 ### Via cloning
@@ -181,7 +179,6 @@ To do that:
     (use-package org-roam-bibtex
       :after org-roam
       :load-path "~/projects/org-roam-bibtex/" ; Modify with your own path where you cloned the repository
-      :hook (org-roam-mode . org-roam-bibtex-mode)
       :config
       (require 'org-ref)) ; optional: if Org Ref is not loaded anywhere else, load it here
     ```
@@ -189,10 +186,9 @@ To do that:
     b) Alternatively, if you don't use `use-package`: 
 
     ```emacs-lisp
+    (require 'org-ref) ; optional: if Org Ref is not loaded anywhere else, load it here
     (add-to-list 'load-path "~/projects/org-roam-bibtex/") ; Modify with your own path where you cloned the repository
     (require 'org-roam-bibtex)
-    (add-hook 'org-roam-mode-hook #'org-roam-bibtex-mode)
-    (require 'org-ref) ; optional: if Org Ref is not loaded anywhere else, load it here
     ```
 
 ### Spacemacs
@@ -208,7 +204,6 @@ If you have a private `org-roam` layer, modify it as follows:
 (defun org-roam/init-org-roam-bibtex ()
   (use-package org-roam-bibtex
     :after org-roam
-    :hook (org-roam-mode . org-roam-bibtex-mode)
     :config
     (require 'org-ref)) ; optional: if Org Ref is not loaded anywhere else, load it here
 ```
@@ -243,7 +238,6 @@ use the approach described in the above mentioned resources.
 ``` emacs-lisp
 (use-package! org-roam-bibtex
   :after org-roam
-  :hook (org-roam-mode . org-roam-bibtex-mode)
   :config
   (require 'org-ref)) ; optional: if Org Ref is not loaded anywhere else, load it here
 ```
@@ -252,6 +246,11 @@ use the approach described in the above mentioned resources.
 
 Usage
 ---------------
+
+#### `org-roam-bibtex-mode`
+
+Call interactively `org-roam-bibtex-mode` or arrange your init file to perform
+this automatically.
 
 You can now access your bibliographical notes in `org-roam-directory` with
 `helm-bibtex`/`ivy-bibtex` or by opening `org-ref` links.  ORB modifies the

--- a/README.md
+++ b/README.md
@@ -263,24 +263,13 @@ disable `org-roam-bibtex-mode`.
 
 Type `M-x orb-note-actions` to easily access additional commands useful in
 note's context.  These commands are run with the note's BibTeX key as an
-argument. The key is taken from the `#+ROAM_KEY:` file property.
+argument. The key is taken from the `:ROAM_REFS:` file or heading property.
 
-#### `orb-insert`
+#### `orb-insert-link`
 
 Select a bibliography entry and insert a link to a note associated with it.  If
-the note does not exist yet, create it.  Similar to `org-roam-insert`, if a
+the note does not exist yet, create it.  Similar to `org-roam-node-insert`, if a
 region is selected, it becomes the link description.
-
-#### `orb-insert-non-ref`
-
-Similar to `orb-insert`, but excludes bibliographical notes from the
-completion-list.
-
-#### `orb-find-non-ref-file`
-
-Similar to `org-roam-find-file`, but excludes bibliographical notes from the
-completion-candidates.  This is useful if you have a lot of them and do not
-want to clutter up your other notes.
 
 Configuration
 ---------------

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Description
 
 Org Roam BibTeX (ORB) is an Org Roam extension that integrates [Org
 Roam](https://github.com/jethrokuan/org-roam) with [Helm and Ivy
-BibTeX](https://github.com/tmalsburg/helm-bibtex) and 
-[Org Ref](https://github.com/jkitchin/org-ref).
+BibTeX](https://github.com/tmalsburg/helm-bibtex) and [Org
+Ref](https://github.com/jkitchin/org-ref).
 
 It allows users to manage their bibliographical notes using Org Roam and access
 the notes in `org-roam-directory` via `helm-bibtex`, `ivy-bibtex`, or by
@@ -36,6 +36,20 @@ Here is a selection of articles that you may find interesting.
 
 #### Workflow
 - [An Orgmode Note Workflow](https://rgoswami.me/posts/org-note-workflow/) by [@HaoZeke](https://github.com/HaoZeke) (outdated).
+
+Important news 
+---------------------------------
+
+Org Roam BibTeX v0.5.1 is the last version of ORB that works with Org-roam v1.
+Future releases of ORB starting with v0.6 will work only with Org-roam v2 and
+will not be backwards compatible with ORB < v0.6.  There will be no deprecation
+notices on functions and variables!
+
+The `master` branch will be kept on v0.5.1 for a while. 
+
+The yet unreleased version compatible with Org-roam v2 can be found on the
+`org-roam-v2` branch for testing and early adoption.  It will be eventually
+merged into `master`.
 
 A word of warning 🚧
 ---------------
@@ -68,11 +82,11 @@ kindly ask you to follow these simple rules when asking for help:
 4. Open an issue on the bug tracker.
 5. Take your time to describe your problem and we'll take ours to help you solve it.
 6. Describe your problem clearly, in a procedural way: "I run `this command`,
-then I run `that command`, and finally `this one`.  I expect `this` to happen but
-instead happens `that`.  Here is my `configuration`."
+then I run `that command`, and finally `this one`.  I expect `this` to happen
+but instead happens `that`.  Here is my `configuration`."
 7. Thank you!
 
-Keep in mind that ORB is under a heavy development and the configuration
+Keep in mind that ORB is under active development and the configuration
 snippets that you might have found somewhere in the Internet may be outdated
 and be the actual cause your errors.  It is therefore highly recommended to use
 this README file, [the manual](doc/orb-manual.org) and the Emacs built-in

--- a/doc/orb-manual.org
+++ b/doc/orb-manual.org
@@ -25,7 +25,7 @@ bibliographical note. It builds on the syntax of
 =org-capture-templates=) by allowing you to expand predefined variables
 with values of BibTeX fields.
 
-See =orb-edit-notes= and
+See =orb-edit-note= and
 [[#orb-preformat-keywords][=orb-preformat-keywords=]] for details. (You
 can access the docstrings of any loaded function/variable from within
 Emacs with =C-h f= for functions/commands, and =C-h v= for variables.)
@@ -92,7 +92,7 @@ Special cases:
   used only within the =:head= section of the templates.
 
 This variable takes effect when orb-preformat-templates is set to t
-(default). See also orb-edit-notes for further details.
+(default). See also orb-edit-note for further details.
 
 Consult the
 [[https://github.com/tmalsburg/helm-bibtex][=bibtex-completion=]]

--- a/doc/orb-manual.org
+++ b/doc/orb-manual.org
@@ -40,15 +40,15 @@ If there are more than one template in =orb-roam-capture-templates=, you will
 be prompted for the key of the template you want to use (=r= in the example
 above).  Otherwise, the only template will be used without prompting.
 
-** =orb-preformat-keywords=
+** User option =orb-preformat-keywords=
 :PROPERTIES:
 :CUSTOM_ID: orb-preformat-keywords
 :END:
 
 A list of template placeholders for pre-expanding. Any BibTeX field can be set
-for preformatting including =bibtex-completion='s' "virtual" fields such as
-=key=' and '=type='. BibTeX fields can be refered to by means of their aliases
-defined in =orb-bibtex-field-aliases=.
+for preformatting including Bibtex-completion virtual fields such as =key=' and
+'=type='. BibTeX fields can be referred by their aliases defined in
+[[#orb-bibtex-field-aliases][=orb-bibtex-field-aliases=]].
 
 Usage example:
 
@@ -63,7 +63,7 @@ Usage example:
          :unnarrowed t)))
 #+end_src
 
-By default, =org-preformat-keywords= is configured to expand the following
+By default, =orb-preformat-keywords= is configured to expand the following
 BibTeX fields: "citekey", "date", "entry-type", "pdf?", "note?", "author",
 "editor", "author-abbrev", "editor-abbrev", "author-or-editor-abbrev".
 
@@ -81,35 +81,46 @@ This variable takes effect when =orb-preformat-templates= is set to t
 Consult the [[https://github.com/tmalsburg/helm-bibtex][=bibtex-completion=]] package for additional information about BibTeX
 field names.
 
+** User option =orb-bibtex-field-aliases=
+:PROPERTIES:
+:CUSTOM_ID: orb-bibtex-field-aliases
+:END:
+
+** Command =orb-insert-link=
+
 ** =orb-insert= configuration
 :PROPERTIES:
 :CUSTOM_ID: orb-insert-configuration
 :END:
-*** =orb-insert-interface=
+** User option =orb-insert-interface=
 :PROPERTIES:
 :CUSTOM_ID: orb-insert-interface
 :END:
-Interface to use with =orb-insert=. Supported interfaces are
-=helm-bibtex=, =ivy-bibtex=, and =generic= (=orb-insert-generic=)
 
-*** =orb-insert-link-description=
+Interface to use with =orb-insert=. Supported interfaces are =helm-bibtex=,
+=ivy-bibtex=, and =generic= (=orb-insert-generic=)
+
+** User option =orb-insert-link-description=
 :PROPERTIES:
 :CUSTOM_ID: orb-insert-link-description
 :END:
-What piece of information should be used as the link description:
+What piece of information should be used as link description by default:
 
 - =title= - entry's title
 - =citekey= - entry's citation key
-- =citation= - insert Org-ref citation (default "cite:") instead of a
-  file link.
+- =citation= - insert Org-ref citation (default "cite:") instead of a file
+  link.
 
-*** =orb-insert-follow-link=
+This setting can be overriden for a single invocation of =orb-insert-link= with
+a numerical prefix.
+
+** User option =orb-insert-follow-link=
 :PROPERTIES:
 :CUSTOM_ID: orb-insert-follow-link
 :END:
 Whether to follow a newly created link.
 
-*** =orb-insert-generic-candidates-format=
+** User option =orb-insert-generic-candidates-format=
 :PROPERTIES:
 :CUSTOM_ID: orb-insert-generic-candidates-format
 :END:

--- a/doc/orb-manual.org
+++ b/doc/orb-manual.org
@@ -5,98 +5,81 @@
 This manual is work in progress and is not complete.  For basic commands see
 [[file:../README.md]].
 
-The following sections use Emacs Lisp examples to configure Org Roam BibTeX. If
-you are not comfortable with Lisp yet, remember you can always use the
-Customize interface to achieve the same, run =M-x customize= or from menu click
-=Options -> Customize Emacs -> Top Level Customization Group= and search for
-=org-roam-bibtex=.
+The following sections use Emacs Lisp examples to configure Org Roam
+BibTeX. User options can also be set via the Customize interface: run =M-x
+customize= or from menu click =Options -> Customize Emacs -> Top Level
+Customization Group= and search for =org-roam-bibtex=.
 
 * Org Roam BibTeX - BibTeX aware capture template expansion
 :PROPERTIES:
 :CUSTOM_ID: org-roam-bibtex---bibtex-aware-capture-template-expansion
 :END:
-** =orb-templates=
+** Template pre-expansion
 :PROPERTIES:
-:CUSTOM_ID: orb-templates
+:CUSTOM_ID: templates
 :END:
-This variable specifies the templates to use when creating a new
-bibliographical note. It builds on the syntax of
-=org-roam-capture-templates= (which, in turn, is powered by
-=org-capture-templates=) by allowing you to expand predefined variables
-with values of BibTeX fields.
 
-See =orb-edit-note= and
-[[#orb-preformat-keywords][=orb-preformat-keywords=]] for details. (You
-can access the docstrings of any loaded function/variable from within
-Emacs with =C-h f= for functions/commands, and =C-h v= for variables.)
+Org Roam BibTeX makes it possible to automatically pre-expand Org-capture
+=%^{...}= and Org Roam-style =${...}= template placeholders with values of
+field or fields of a BibTeX entry for which the note is being created.
 
-Here's the default value of =orb-templates=:
+Here's an example of how to add a basic template for a bibliography note to
+`org-roam-capture-templates`:
 
-#+begin_example
-  (("r" "ref" plain (function org-roam-capture--get-point) ""
-        :file-name "${citekey}"
-        :head "#+TITLE: ${title}\n#+ROAM_KEY: ${ref}\n"
-        :unnarrowed t))
-#+end_example
+#+begin_src elisp
+(setq org-roam-capture-templates
+      '(;; ... other templates
+        ;; bibliography note template
+        ("r" "bibliography reference" plain "%?"
+        :if-new
+        (file+head "references/${citekey}.org" "#+title: ${title}\n")
+        :unnarrowed t)))
+#+end_src
 
-You can modify it with =setq=. For instance, if you want to add the
-cite-key in the title of the notes, you can modify the code like this
-(pay attention to the line with =:head=):
-
-#+begin_example
-  (setq orb-templates
-        '(("r" "ref" plain (function org-roam-capture--get-point) ""
-           :file-name "${citekey}"
-           :head "#+TITLE: ${citekey}: ${title}\n#+ROAM_KEY: ${ref}\n" ; <--
-           :unnarrowed t)))
-#+end_example
-
-If you have more than one template in =orb-templates=, you will be
-prompted for the key of the template you want to use (=r= in the example
-above). If you only have one template, it will use this one without
-prompting you.
+If there are more than one template in =orb-roam-capture-templates=, you will
+be prompted for the key of the template you want to use (=r= in the example
+above).  Otherwise, the only template will be used without prompting.
 
 ** =orb-preformat-keywords=
 :PROPERTIES:
 :CUSTOM_ID: orb-preformat-keywords
 :END:
-A list of template prompt wildcards for preformatting. Any BibTeX field
-can be set for preformatting including =bibtex-completion='s' "virtual"
-fields such as =key=' and '=type='. BibTeX fields can be refered to by
-means of their aliases defined in orb-bibtex-field-aliases.
+
+A list of template placeholders for pre-expanding. Any BibTeX field can be set
+for preformatting including =bibtex-completion='s' "virtual" fields such as
+=key=' and '=type='. BibTeX fields can be refered to by means of their aliases
+defined in =orb-bibtex-field-aliases=.
 
 Usage example:
 
-#+begin_example
-  (setq orb-preformat-keywords '("citekey" "author" "date"))
-  (setq orb-templates
-        '((\"r\" \"reference\" plain (function org-roam-capture--get-point)
-           "#+ROAM_KEY: %^{citekey}%?
-  %^{author} published %^{entry-type} in %^{date}: fullcite:%\\1."
-           :file-name "references/${citekey}"
-           :head "#+TITLE: ${title}"
-           :unnarrowed t)))
-#+end_example
+#+begin_src elisp
+(setq orb-preformat-keywords '("citekey" "author" "date"))
+(setq org-roam-capture-templates
+      '(("r" "bibliography reference" plain
+         "%?
+%^{author} published %^{entry-type} in %^{date}: fullcite:%\\1."
+         :if-new
+         (file+head "references/${citekey}.org" "#+title: ${title}\n")
+         :unnarrowed t)))
+#+end_src
 
-By default, =org-preformat-keywords= is configured to expand the
-following BibTeX fields: "citekey", "date", "entry-type", "pdf?",
-"note?", "author", "editor", "author-abbrev", "editor-abbrev",
-"author-or-editor-abbrev".
+By default, =org-preformat-keywords= is configured to expand the following
+BibTeX fields: "citekey", "date", "entry-type", "pdf?", "note?", "author",
+"editor", "author-abbrev", "editor-abbrev", "author-or-editor-abbrev".
 
 Special cases:
 
 - The "file" keyword will be treated specially if the value of
   `orb-process-file-keyword' is non-nil. See its docstring for an
   explanation.
-- The "title" keyword needs not to be set for preformatting if it is
-  used only within the =:head= section of the templates.
+- The "title" keyword needs not to be set for preformatting if it is used only
+  within the =:if-new= section of a template.
 
-This variable takes effect when orb-preformat-templates is set to t
-(default). See also orb-edit-note for further details.
+This variable takes effect when =orb-preformat-templates= is set to t
+(default). See also =orb-edit-note= for further details.
 
-Consult the
-[[https://github.com/tmalsburg/helm-bibtex][=bibtex-completion=]]
-package for additional information about BibTeX field names.
+Consult the [[https://github.com/tmalsburg/helm-bibtex][=bibtex-completion=]] package for additional information about BibTeX
+field names.
 
 ** =orb-insert= configuration
 :PROPERTIES:
@@ -149,24 +132,23 @@ interface:
 Long templates can be placed in a separate file, with template expansion
 of BibTeX fields working as usual:
 
-#+begin_example
-  (setq org-roam-capture-templates
-        '(("r" "reference" plain (function org-roam-capture--get-point)
-           (file "/path/to/template.org") ; <--
-           :file-name "test/${citekey}"
-           :head "#+TITLE: ${title}\n"
-           :unnarrowed t)))
-#+end_example
+#+begin_src elisp
+(setq org-roam-capture-templates
+      '(("r" "bibliography reference" plain
+         (file "/path/to/template.org") ; <-- template store in a separate file
+         :if-new
+         (file+head "references/${citekey}.org" "#+title: ${title}\n")
+         :unnarrowed t)))
+#+end_src
 
 Content of =path/to/template.org=:
 
 #+begin_src org
-  ,#+ROAM_KEY: %^{citekey}
-,#+PROPERTY: type %^{type}
-,#+ROAM_TAGS: %^{keywords}
+,#+PROPERTY: type %^{entry-type}
+,#+FILETAGS: %^{keywords}
 ,#+PROPERTY: authors %^{author}
 
-In this %\2 %\4 concluded that %?
+In this %\1 %\3 concluded that %?
 
 fullcite:%\1
 #+end_src
@@ -178,46 +160,44 @@ You can also use a function to generate the template on the fly, see
 :PROPERTIES:
 :CUSTOM_ID: org-noter-integration.-special-treatment-of-the-file-keyword
 :END:
-If =orb-process-file-keyword= is non-nil, the "file" field will be
-treated specially. If the field contains only one file name, its value
-will be used for template expansion. If it contains several file names,
-the user will be prompted to choose one. The file names can be filtered
-based on their extensions by setting the =orb-file-field-extensions=
-variable, so that only those matching the extension or extensions will
-be considered for retrieval. The "file" keyword must be set for
-preformatting as usual. Consult the docstrings of these variables for
-additional customization options.
 
-Below shows how this can be used to integrate with
-[[https://github.com/weirdNox/org-noter][org-noter]] or
-[[https://github.com/rudolfochrist/interleave][interleave]]:
+If =orb-process-file-keyword= is non-nil, the "file" field will be treated
+specially. If the field contains only one file name, its value will be used for
+template expansion. If it contains several file names, the user will be
+prompted to choose one. The file names can be filtered based on their
+extensions by setting the =orb-file-field-extensions= variable, so that only
+those matching the extension or extensions will be considered for
+retrieval. The "file" keyword must be set for preformatting as usual. Consult
+the docstrings of these variables for additional customization options.
 
-#+begin_example
-  (setq orb-preformat-keywords
-        '("citekey" "title" "url" "author-or-editor" "keywords" "file")
-        orb-process-file-keyword t
-        orb-file-field-extensions '("pdf"))
+Below shows how this can be used to integrate with [[https://github.com/weirdNox/org-noter][org-noter]] or [[https://github.com/rudolfochrist/interleave][interleave]]:
 
-  (setq orb-templates
-        '(("r" "ref" plain (function org-roam-capture--get-point)
-           ""
-           :file-name "${citekey}"
-           :head "#+TITLE: ${citekey}: ${title}\n#+ROAM_KEY: ${ref}
+#+begin_src elisp
+(setq orb-preformat-keywords
+      '("citekey" "title" "url" "author-or-editor" "keywords" "file")
+      orb-process-file-keyword t
+      orb-file-field-extensions '("pdf"))
 
-  - tags ::
-  - keywords :: ${keywords}
+(setq org-roam-capture-templates
+      '(("r" "bibliography reference" plain
+         (file "/path/to/template")
+         :if-new
+         (file+head "references/${citekey}.org" "#+title: ${title}\n"))))
+#+end_src
 
-  * ${title}
-  :PROPERTIES:
-  :Custom_ID: ${citekey}
-  :URL: ${url}
-  :AUTHOR: ${author-or-editor}
-  :NOTER_DOCUMENT: ${file}  ; <== special file keyword: if more than one filename
-  :NOTER_PAGE:              ;     is available, the user will be prompted to choose
-  :END:")))
-#+end_example
+#+begin_src org
+- tags ::
+- keywords :: %^{keywords}
 
-Do not forget to escape the quotes inside the =%=-escapes form!
+,* %^{title}
+:PROPERTIES:
+:Custom_ID: %^{citekey}
+:URL: %^{url}
+:AUTHOR: %^{author-or-editor}
+:NOTER_DOCUMENT: %^{file}  ; <== special file keyword: if more than one filename
+:NOTER_PAGE:               ;     is available, the user will be prompted to choose
+:END:
+#+end_src
 
 * ORB Note Actions - BibTeX record-related commands
 :PROPERTIES:
@@ -227,17 +207,17 @@ Do not forget to escape the quotes inside the =%=-escapes form!
 :PROPERTIES:
 :CUSTOM_ID: overview
 :END:
-Type =M-x orb-note-actions= or bind this command to a key such as
-=C-c n a= to quickly access additional commands that take the note's
-BibTeX key as an input and process it to perform some useful actions.
 
-Note actions are divided into three groups: =default=, =extra=, and
-=user= set via =orb-note-actions-default=, =orb-note-actions-extra=,
-=orb-note-actions-user=, respectively. There is no big conceptual
-difference between the three except that the =default= note actions are
-commands provided by =bibtex-completion=, =extra= note actions are extra
-commands provided by =org-roam-bibtex=, and =user= note actions are left
-for user customization.
+Type =M-x orb-note-actions= or bind this command to a key such as =C-c n a= to
+quickly access additional commands that take the note's BibTeX key as an input
+and process it to perform some useful actions.
+
+Note actions are divided into three groups: =default=, =extra=, and =user= set
+via =orb-note-actions-default=, =orb-note-actions-extra=,
+=orb-note-actions-user=, respectively. There is no big conceptual difference
+between the three except that the =default= note actions are commands provided
+by =bibtex-completion=, =extra= note actions are extra commands provided by
+=org-roam-bibtex=, and =user= note actions are left for user customization.
 
 ** Note actions interface
 :PROPERTIES:
@@ -252,17 +232,21 @@ and =hydra=. The interface can be set via the
   (setq orb-note-actions-interface 'hydra)
 #+end_example
 
-Alternatively, =orb-note-actions-interface= can be set to a custom
-function that will provide completion for available note actions. The
-function must take one argument CITEKEY, which is a list whose =car= is
-the current note's citation key:
+Alternatively, =orb-note-actions-interface= can be set to a custom function
+that will provide completion for available note actions. The function must take
+one argument CITEKEY, which is a list whose =car= is the current note's
+citation key:
 
 #+begin_example
   (setq orb-note-actions-interface #'my-orb-note-actions-interface)
 #+end_example
 
 #+begin_src org
-  ,#+ROAM_KEY: cite:Doe2020
+:PROPERTIES:
+:ID: uuid1234-...
+:ROAM_REFS: cite:Doe2020
+:END:
+,#+title: My note
 #+end_src
 
 #+begin_example

--- a/orb-compat.el
+++ b/orb-compat.el
@@ -30,15 +30,6 @@
 ;;; Code:
 
 ;; * org-roam-bibtex.el
-(define-obsolete-variable-alias
-  'orb-insert-frontend 'orb-insert-interface "0.5")
-(define-obsolete-variable-alias
-  'orb-note-actions-frontend 'orb-note-actions-interface "0.5")
-
-(define-obsolete-variable-alias
-  'orb-pdf-scrapper-refsection-headings 'orb-pdf-scrapper-grouped-export "0.5")
-(define-obsolete-variable-alias
-  'orb-pdf-scrapper-export-fields 'orb-pdf-scrapper-table-export-fields "0.5")
 
 (provide 'orb-compat)
 ;;; orb-compat.el ends here

--- a/orb-helm.el
+++ b/orb-helm.el
@@ -38,7 +38,7 @@
 
 (declare-function org-ref-format-entry "ext:org-ref-bibtex" (key))
 
-(declare-function orb-insert-edit-notes "org-roam-bibtex" (citekey))
+(declare-function orb-insert-edit-note "org-roam-bibtex" (citekey))
 
 (defvar orb-note-actions-default)
 (defvar orb-note-actions-extra)
@@ -66,7 +66,7 @@
     :candidates 'helm-bibtex-candidates
     :filtered-candidate-transformer 'helm-bibtex-candidates-formatter
     :action (helm-make-actions
-             "Edit note & insert a link"  'helm-orb-insert-edit-notes
+             "Edit note & insert a link"  'helm-orb-insert-edit-note
              "Open PDF, URL or DOI"       'helm-bibtex-open-any
              "Open URL or DOI in browser" 'helm-bibtex-open-url-or-doi
              "Insert citation"            'helm-bibtex-insert-citation
@@ -78,10 +78,10 @@
              "Add PDF to library"     'helm-bibtex-add-pdf-to-library))
   "Helm source to use with `orb-insert'.
 A copy of `helm-source-bibtex', in which \"Edit notes\" is made
-the first (default) action.  This action calls `helm-orb-insert-edit-notes'.
+the first (default) action.  This action calls `helm-orb-insert-edit-note'.
 Only relevant when `orb-insert-interface' is `helm-bibtex'.")
 
-(helm-bibtex-helmify-action orb-insert-edit-notes helm-orb-insert-edit-notes)
+(helm-bibtex-helmify-action orb-insert-edit-note helm-orb-insert-edit-note)
 
 (defun orb-helm-insert (&optional clear-cache)
   "Run `helm-bibtex'.

--- a/orb-ivy.el
+++ b/orb-ivy.el
@@ -37,7 +37,7 @@
 
 (declare-function org-ref-format-entry "ext:org-ref-bibtex" (key))
 
-(declare-function orb-insert-edit-notes "org-roam-bibtex" (citekey))
+(declare-function orb-insert-edit-note "org-roam-bibtex" (citekey))
 
 (defvar orb-note-actions-default)
 (defvar orb-note-actions-extra)
@@ -60,7 +60,7 @@
 ;; ============================================================================
 
 (defvar orb-insert--ivy-actions
-  '(("e" ivy-orb-insert-edit-notes "Edit note & insert a link")
+  '(("e" ivy-orb-insert-edit-note "Edit note & insert a link")
     ("p" ivy-bibtex-open-pdf "Open PDF file (if present)")
     ("u" ivy-bibtex-open-url-or-doi "Open URL or DOI in browser")
     ("c" ivy-bibtex-insert-citation "Insert citation")
@@ -74,10 +74,10 @@
   "Ivy actions to use with `orb-insert'.
 A copy of Ivy-bibtex's alist defining Ivy actions, in which
 \"Edit note & insert a link\" is made first (default) action.
-This action calls `orb-insert-edit-notes'.  Only relevant when
+This action calls `orb-insert-edit-note'.  Only relevant when
 `orb-insert-interface' is `ivy-bibtex'.")
 
-(ivy-bibtex-ivify-action orb-insert-edit-notes ivy-orb-insert-edit-notes)
+(ivy-bibtex-ivify-action orb-insert-edit-note ivy-orb-insert-edit-note)
 
 (defun orb-ivy-insert (&optional clear-cache)
   "Run `ivy-bibtex'.
@@ -87,7 +87,7 @@ This is a simple wrapper to be run from `orb-insert'."
   (let* ((ivy-actions (copy-tree ivy--actions-list))
          (ivy--actions-list
           (plist-put ivy-actions 'ivy-bibtex orb-insert--ivy-actions))
-         (ivy-bibtex-default-action 'ivy-orb-insert-edit-notes))
+         (ivy-bibtex-default-action 'ivy-orb-insert-edit-note))
     (ivy-bibtex clear-cache)))
 
 (provide 'orb-ivy)

--- a/orb-utils.el
+++ b/orb-utils.el
@@ -45,6 +45,7 @@
 ;; so all these libraries are always at our disposal
 
 (require 'org-roam)
+(require 'bibtex-completion)
 
 (require 'warnings)
 

--- a/orb-utils.el
+++ b/orb-utils.el
@@ -45,8 +45,6 @@
 ;; so all these libraries are always at our disposal
 
 (require 'org-roam)
-(require 'org-roam-reflinks)
-(require 'org-roam-node)
 
 (require 'warnings)
 

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -466,8 +466,7 @@ Keyword \"%s\" has invalid type (string was expected)" keyword))))
         (when roam-template
           (setcdr roam-template
                   (funcall expand-roam-template
-                           (cdr roam-template) roam-wildcard field-value))
-          (plist-put plst :if-new roam-template))))
+                           (cdr roam-template) roam-wildcard field-value)))))
     ;; Second run: replace prompts and prompt matches in org-capture
     ;; template string
     (dolist (l lst)
@@ -477,7 +476,7 @@ Keyword \"%s\" has invalid type (string was expected)" keyword))))
           ;; replace prompt wildcards with BibTeX field value
           (setq org-template (s-replace pos (car l) org-template)
                 org-template (s-replace (car l) (nth 1 l) org-template))))
-      (setf (nth 4 template) org-template))
+      (setf (nth 3 template) org-template))
     template))
 
 (defun orb--new-note (citekey &optional props)

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -950,6 +950,7 @@ CITEKEY is a list whose car is a citation key."
 ;; ============================================================================
 ;;
 
+;;;###autoload
 (defun orb-org-ref-edit-note (citekey)
   "Open an Org-roam note associated with the CITEKEY or create a new one.
 Set `org-ref-notes-function' to this function if your
@@ -962,6 +963,7 @@ intended for use with Org-ref."
     (let ((bibtex-completion-bibliography (org-ref-find-bibliography)))
       (orb-edit-note citekey))))
 
+;;;###autoload
 (defun orb-edit-notes (keys)
   "Open or create an Org-roam note associated with the first key from KEYS.
 This function replaces `bibtex-completion-edit-notes'.  Only the

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -121,18 +121,6 @@ See `orb-edit-note' for details."
           (const :tag "No" nil))
   :group 'org-roam-bibtex)
 
-(defcustom orb-templates
-  '(("r" "bibliography reference" plain
-     (function org-roam-capture--get-point)
-     "%?"
-     :file-name "${citekey}"
-     :head "#+TITLE: ${title}\n#+CITEKEY: ${citekey}"
-     :unnarrowed t))
-  "Template to use when creating a new note.
-See `orb-edit-note' for details."
-  :type '(list)
-  :group 'org-roam-bibtex)
-
 (defcustom orb-include-citekey-in-titles nil
   "Non-nil to include the citekey in titles.
 See `orb-edit-note' for details."
@@ -1143,7 +1131,7 @@ user actions can be set in `orb-note-actions-user'."
   (let ((non-default-interfaces (list 'hydra 'ido 'ivy 'helm))
         ;; FIXME: this does not work anymore
         ;; (citekey (cdr (org-roam--extract-ref)))
-        (citekey "NOT IMPLEMENTED V2"))
+        (citekey (orb-get-node-citekey)))
     (if citekey
         (cond ((member orb-note-actions-interface non-default-interfaces)
                (orb-note-actions--run orb-note-actions-interface citekey))
@@ -1151,8 +1139,8 @@ user actions can be set in `orb-note-actions-user'."
                (funcall orb-note-actions-interface citekey))
               (t
                (orb-note-actions--run 'default citekey)))
-      (user-error "Could not retrieve the citekey.  Probably no #+ROAM_KEY: in\
-the buffer or package Org Ref not installed"))))
+      (user-error "Could not retrieve the citekey.  Check ROAM_REFS property \
+of current node"))))
 
 ;;;;;; Note actions
 

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -493,7 +493,8 @@ The value of the current citekey for `orb--add-ref'.")
   "Add citeky as Org-roam ref to the current buffer.
 To be used in `org-roam-capture-new-node-hook'."
   (save-excursion
-    (org-roam-add-property orb--current-citekey "ROAM_REFS")))
+    (if orb--current-citekey
+        (org-roam-add-property orb--current-citekey "ROAM_REFS"))))
 
 (defun orb--new-note (citekey &optional props)
   "Process templates and run `org-roam-capture-'.

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -7,7 +7,7 @@
 ;;      Leo Vivier <leo.vivier+dev@gmail.com>
 ;; URL: https://github.com/org-roam/org-roam-bibtex
 ;; Keywords: bib, hypermedia, outlines, wp
-;; Version: 0.5.0
+;; Version: 0.6.0
 ;; Package-Requires: ((emacs "27.1") (org-roam "2.0.0") (bibtex-completion "2.0.0") (org-ref "1.1.1"))
 
 ;; Soft dependencies: projectile, persp-mode, helm, ivy, hydra

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -8,7 +8,7 @@
 ;; URL: https://github.com/org-roam/org-roam-bibtex
 ;; Keywords: bib, hypermedia, outlines, wp
 ;; Version: 0.6.0
-;; Package-Requires: ((emacs "27.1") (org-roam "2.0.0") (bibtex-completion "2.0.0") (org-ref "1.1.1"))
+;; Package-Requires: ((emacs "27.2") (org-roam "2.0.0") (bibtex-completion "2.0.0") (org-ref "1.1.1"))
 
 ;; Soft dependencies: projectile, persp-mode, helm, ivy, hydra
 

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -585,6 +585,7 @@ before calling any Org-roam functions."
   ;; Optionally switch to the notes perspective
   (when orb-switch-persp
     (orb--switch-perspective))
+  (orb-make-notes-cache)
   (if-let ((node (orb-note-exists-p citekey)))
       ;; Find org-roam reference with the CITEKEY and collect data into
       ;; `orb-plist'
@@ -818,6 +819,7 @@ choosing a candidate the appropriate link will be inserted."
                    (or description orb-insert-link-description)
                    :link-lowercase
                    (or lowercase orb-insert-lowercase))
+    (orb-make-notes-cache)
     (cl-case orb-insert-interface
       (helm-bibtex
        (cond
@@ -983,10 +985,6 @@ This function replaces `bibtex-completion-edit-notes'.  Only the
 first key from KEYS will actually be used."
   (orb-edit-note (car keys)))
 
-(defun orb-bibtex-completion-parse-bibliography-ad (&optional _ht-strings)
-  "Update `orb-notes-cache' before `bibtex-completion-parse-bibliography'."
-  (orb-make-notes-cache))
-
 (defvar org-roam-bibtex-mode-map
   (make-sparse-keymap)
   "Keymap for `org-roam-bibtex-mode'.")
@@ -1014,8 +1012,8 @@ interactively."
          (add-to-list 'bibtex-completion-find-note-functions
                       #'orb-find-note-file)
          (setq bibtex-completion-edit-notes-function #'orb-edit-notes)
-         (advice-add 'bibtex-completion-parse-bibliography
-                     :before #'orb-bibtex-completion-parse-bibliography-ad))
+         (add-hook 'org-capture-after-finalize-hook #'orb-make-notes-cache)
+         (orb-make-notes-cache))
         (t
          (setq org-ref-notes-function 'org-ref-notes-function-one-file)
          (setq bibtex-completion-find-note-functions
@@ -1023,8 +1021,8 @@ interactively."
                      bibtex-completion-find-note-functions))
          (setq bibtex-completion-edit-notes-function
                #'bibtex-completion-edit-notes-default)
-         (advice-remove 'bibtex-completion-parse-bibliography
-                        #'orb-bibtex-completion-parse-bibliography-ad))))
+         (remove-hook 'org-capture-after-finalize-hook
+                        #'orb-make-notes-cache))))
 
 (provide 'org-roam-bibtex)
 

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -551,32 +551,45 @@ is the function `ignore', it is added as `:override'."
 TEMPLATE is an element of `org-roam-capture-templates' and ENTRY
 is a BibTeX entry as returned by `bibtex-completion-get-entry'."
   ;; Handle org-roam-capture part
-  (let* (;; Org-capture templates: handle different types of
-         ;; org-capture-templates: string, file and function; this is
-         ;; a stripped down version of `org-capture-get-template'
-         (tp
-          (pcase (nth 3 template)       ; org-capture template is here
-            (`nil 'nil)
-            ((and (pred stringp) tmpl) tmpl)
-            (`(file ,file)
-             (let ((flnm (expand-file-name file org-directory)))
-               (if (file-exists-p flnm) (f-read-text flnm)
-                 (format "Template file %S not found" file))))
-            (`(function ,fun)
-             (if (functionp fun) (funcall fun)
-               (format "Template function %S not found" fun)))
-            (_ (user-error "ORB: Invalid capture template"))))
-         ;;  org-roam capture properties are here
-         (plst (cddddr template))
-         ;; regexp for org-capture prompt wildcard
-         (rx "\\(%\\^{[[:alnum:]-_]*}\\)")
-         (file-keyword (when orb-process-file-keyword
-                         (or (and (stringp orb-process-file-keyword)
-                                  orb-process-file-keyword)
-                             "file")))
-         lst)
+  (letrec (;; Org-capture templates: handle different types of
+           ;; org-capture-templates: string, file and function; this is
+           ;; a stripped down version of `org-capture-get-template'
+           (org-template
+            (pcase (nth 3 template)       ; org-capture template is here
+              (`nil 'nil)
+              ((and (pred stringp) tmpl) tmpl)
+              (`(file ,file)
+               (let ((flnm (expand-file-name file org-directory)))
+                 (if (file-exists-p flnm) (f-read-text flnm)
+                   (format "Template file %S not found" file))))
+              (`(function ,fun)
+               (if (functionp fun) (funcall fun)
+                 (format "Template function %S not found" fun)))
+              (_ (user-error "ORB: Invalid capture template"))))
+           ;;  org-roam capture properties are here
+           (plst (cddddr template))
+           ;; regexp for org-capture prompt wildcard
+           (rx "\\(%\\^{[[:alnum:]-_]*}\\)")
+           (file-keyword (when orb-process-file-keyword
+                           (or (and (stringp orb-process-file-keyword)
+                                    orb-process-file-keyword)
+                               "file")))
+           ;; inline function to handle :if-new list expansion
+           (expand-roam-template
+            (lambda (roam-template-list old new)
+              (let (elements)
+                (dolist (el roam-template-list)
+                  (if (listp el)
+                      (setq elements
+                            (nreverse
+                             (append elements
+                                     (list (funcall expand-roam-template
+                                                    el old new)))))
+                    (push (s-replace old new el) elements)))
+                (nreverse elements))))
+           (lst nil))
     ;; First run:
-    ;; 1) Make a list of (rplc-s field-value match-position) for the
+    ;; 1) Make a list of (org-wildcard field-value match-position) for the
     ;; second run
     ;; 2) replace org-roam-capture wildcards
     (dolist (keyword orb-preformat-keywords)
@@ -608,38 +621,38 @@ Keyword \"%s\" has invalid type (string was expected)" keyword))))
                       (error "")))
                   ""))
              ;; org-capture prompt wildcard
-             (rplc-s (concat "%^{" (or keyword "citekey") "}"))
+             (org-wildcard (concat "%^{" (or keyword "citekey") "}"))
              ;; org-roam-capture prompt wildcard
-             (rplc-s2 (concat "${" (or keyword "citekey") "}"))
+             (roam-wildcard (concat "${" (or keyword "citekey") "}"))
              ;; org-roam-capture :if-new property
-             (if-new (plist-get plst :if-new))
-             (i 1)                        ; match counter
+             (roam-template (plist-get plst :if-new))
+             (i 1)                      ; match counter
              pos)
-        ;; Search for rplc-s, set flag m if found
-        (when tp
-          (while (string-match rx tp pos)
-            (if (string= (match-string 1 tp) rplc-s)
+        ;; Search for org-wildcard, set flag m if found
+        (when org-template
+          (while (string-match rx org-template pos)
+            (if (string= (match-string 1 org-template) org-wildcard)
                 (progn
-                  (setq pos (length tp))
-                  (cl-pushnew (list rplc-s field-value i) lst ))
+                  (setq pos (length org-template))
+                  (cl-pushnew (list org-wildcard field-value i) lst ))
               (setq pos (match-end 1)
                     i (1+ i)))))
         ;; Replace placeholders in org-roam-capture-templates :if-new property
-        (when if-new
-          (let (strings)
-            (dolist (str (cdr if-new))
-              (push (s-replace rplc-s2 field-value str) strings))
-            (plist-put plst :if-new (cons (car if-new) (nreverse strings)))))))
+        (when roam-template
+          (setcdr roam-template
+                  (funcall expand-roam-template
+                           (cdr roam-template) roam-wildcard field-value))
+          (plist-put plst :if-new roam-template))))
     ;; Second run: replace prompts and prompt matches in org-capture
     ;; template string
     (dolist (l lst)
-      (when (and tp (nth 1 l))
+      (when (and org-template (nth 1 l))
         (let ((pos (concat "%\\" (number-to-string (nth 2 l)))))
           ;; replace prompt match wildcards with prompt wildcards
           ;; replace prompt wildcards with BibTeX field value
-          (setq tp (s-replace pos (car l) tp)
-                tp (s-replace (car l) (nth 1 l) tp))))
-      (setf (nth 4 template) tp))
+          (setq org-template (s-replace pos (car l) org-template)
+                org-template (s-replace (car l) (nth 1 l) org-template))))
+      (setf (nth 4 template) org-template))
     template))
 
 (defun orb--new-note (citekey)
@@ -719,15 +732,7 @@ with the CITEKEY as retrieved by `bibtex-completion-get-entry'.
 The prompt presented by `org-roam-node-find' will thus be
 pre-populated with the record title.
 
-3. The template used to create the note is stored in
-`orb-templates'.  If the variable is not defined, revert to using
-`org-roam-capture-templates'.  In the former case, a new file
-will be created and filled according to the template, possibly
-preformatted (see below) without additional user interaction.  In
-the latter case, an interactive `org-capture' process will be
-run.
-
-4. Optionally, when `orb-preformat-templates' is non-nil, any
+3. Optionally, when `orb-preformat-templates' is non-nil, any
 prompt wildcards in `orb-templates' or
 `org-roam-capture-templates', associated with the bibtex record
 fields as specified in `orb-preformat-templates', will be
@@ -744,7 +749,7 @@ the `org-roam-node-find' interactive prompt since all the
 template expansions will have taken place by then.  All the title
 wildcards will be replace with the BibTeX field value.
 
-5. Optionally, if you are using Projectile and Persp-mode and
+4. Optionally, if you are using Projectile and Persp-mode and
 have a dedicated workspace to work with your Org-roam collection,
 you may want to set the perspective name and project path in
 `orb-persp-project' and `orb-switch-persp' to t.  In this case,
@@ -769,8 +774,9 @@ before calling any Org-roam functions."
       (orb--store-link-functions-advice 'add)
       ;; install capture hook functions
       (orb-do-hook-functions 'add)
+      (orb--new-note citekey)
       (condition-case error-msg
-          (orb--new-note citekey)
+         nil
         ((debug error)
          (with-orb-cleanup
            (orb--store-link-functions-advice 'remove)

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -108,33 +108,25 @@ See `orb-edit-note' for details."
           (const :tag "No" nil))
   :group 'org-roam-bibtex)
 
-(defcustom orb-include-citekey-in-titles nil
-  "Non-nil to include the citekey in titles.
-See `orb-edit-note' for details."
-  :type '(choice
-          (const :tag "Yes" t)
-          (const :tag "No" nil))
-  :group 'org-roam-bibtex)
-
 (defcustom orb-preformat-keywords
   '("citekey" "entry-type" "date" "pdf?" "note?" "file"
     "author" "editor" "author-abbrev" "editor-abbrev"
     "author-or-editor-abbrev")
-  "A list of template prompt wildcards for pre-expanding.
+  "A list of template placeholders for pre-expanding.
 Any BibTeX field can be set for pre-expanding including
-`bibtex-completion` \"virtual\" fields such as '=key=' and
-'=type='.  BibTeX fields can be refered to by means of their
-aliases defined in `orb-bibtex-field-aliases'.
+Bibtex-completion virtual fields such as '=key=' and '=type='.
+BibTeX fields can be referred to by means of their aliases
+defined in `orb-bibtex-field-aliases'.
 
 Usage example:
 
 \(setq orb-preformat-keywords '(\"citekey\" \"author\" \"date\"))
 \(setq orb-templates
-      '((\"r\" \"reference\" plain (function org-roam-capture--get-point)
+      '((\"r\" \"reference\" plain
          \"#+ROAM_KEY: %^{citekey}%?
 %^{author} published %^{entry-type} in %^{date}: fullcite:%\\1.\"
-         :file-name \"references/${citekey}\"
-         :head \"#+TITLE: ${title}\"
+         :if-new
+         (file+head \"references/${citekey.org}\" \"#+title: ${title}\n\")
          :unnarrowed t)))
 
 Special cases:
@@ -143,21 +135,18 @@ The \"file\" keyword will be treated specially if the value of
 `orb-process-file-keyword' is non-nil.  See its docstring for an
 explanation.
 
-The \"title\" keyword needs not to be set for pre-expanding if it
-is used only within the `:head` section of the templates.
-
 This variable takes effect when `orb-preformat-templates' is set
 to t (default). See also `orb-edit-note' for further details.
 
-Consult bibtex-completion package for additional information
-about BibTeX field names."
+Consult Bibtex-completion documentation for additional
+information on BibTeX field names."
   :type '(repeat :tag "BibTeX field names" string)
   :group 'org-roam-bibtex)
 
 (defcustom orb-process-file-keyword t
   "Whether to treat the file keyword specially during template pre-expanding.
 When this variable is non-nil, the \"%^{file}\" and \"${file}\"
-wildcards will be expanded by `org-process-file-field' rather
+wildcards will be processed by `org-process-file-field' rather
 than simply replaced with the field value.  This may be useful in
 situations when the file field contains several file names and
 only one file name is desirable for retrieval.  The \"file\"
@@ -172,11 +161,9 @@ single file name by expanding the %^{my-file} and ${my-file}
 wildcards.  The keyword, e.g. \"my-file\", must be set for
 pre-expanding in `orb-preformat-keywords' as usual.
 
-The variable `orb-file-field-extensions' controls which filtering
-of the file names based on file extensions.
-
-See also `orb-file-field-extensions' for filtering file names
-based on their extension."
+The variable `orb-file-field-extensions' controls filtering of
+file names based on file extensions."
+  ;; TODO: check if a custom string is really working as described
   :group 'org-roam-bibtex
   :type '(choice
           (const :tag "Yes" t)
@@ -184,35 +171,16 @@ based on their extension."
           (string :tag "Custom wildcard keyword")))
 
 (defcustom orb-citekey-format "cite:%s"
-  "Format string for the citekey.
-The citekey obtained from Helm-bibtex/Ivy-bibtex/Org-ref
-will be formatted as specified here."
+  "Format string for the citation key.
+This string will be prepended to the citation key to obtained an
+Org-ref citation, which will be then set in :ROAM_REFS: property."
   :type 'string
-  :group 'org-roam-bibtex)
-
-(defcustom orb-slug-source 'citekey
-  "What should be used as a source for creating the note's slug.
-Supported values are symbols `citekey' and `title'.
-
-A special variable `${slug}` in `orb-templates' (and
-`org-roam-capture-templates') is used as a placeholder for an
-automatically generated string which is meant to be used in
-filenames.  Org Roam uses the note's title to create a slug.  ORB
-also allows for the citekey.  The function specified in
-`org-roam-title-to-slug-function' is used to create the slug.
-This operation typilcally involves removing whitespace and
-converting words to lowercase, among possibly other things."
-  :type '(choice
-          (const citekey)
-          (const title))
   :group 'org-roam-bibtex)
 
 (defcustom orb-persp-project `("notes" . ,org-roam-directory)
   "Perspective name and path to the project with bibliography notes.
 A cons cell (PERSP-NAME . PROJECT-PATH).  Only relevant when
 `orb-switch-persp' is set to t.
-
-Requires command `persp-mode' and command `projectile-mode'.
 
 PERSP-NAME should be a valid Perspective name, PROJECT-PATH should be
 an open Projectile project.
@@ -227,9 +195,7 @@ See `orb-edit-note' for details"
 Set the name of the perspective and the path to the notes project
 in `orb-persp-project' for this to take effect.
 
-Requires command `persp-mode' and command `projectile-mode'.
-
-See `orb-edit-note' for details."
+Perspective switching works with Pers-mode and Projectile."
   :type '(choice
           (const :tag "Yes" t)
           (const :tag "No" nil))
@@ -243,15 +209,15 @@ Org Ref defines function `org-ref-bibtex-store-link' to store
 links to a BibTeX buffer, e.g. with `org-store-link'.  At the
 same time, Org ref requires `ol-bibtex' library, which defines
 `org-bibtex-store-link' to do the same.  When creating a note
-with `orb-edit-note' from a BibTeX buffer, for example by
-calling `org-ref-open-bibtex-notes', the initiated `org-capture'
-process implicitly calls `org-store-link'.  The latter loops
-through all the functions for storing links, and if more than one
-function can store links to the location, the BibTeX buffer in
-this particular case, the user will be prompted to choose one.
-This is definitely annoying, hence ORB will advise all functions
-in this list to return nil to trick `org-capture' and get rid of
-the prompt.
+with `orb-edit-note' from a BibTeX buffer, for example by calling
+`org-ref-open-bibtex-notes', the initiated `org-capture' process
+implicitly calls `org-store-link'.  The latter loops through all
+the functions for storing links, and if more than one function
+can store links to the location, the BibTeX buffer in this
+particular case, the user will be prompted to choose one.  This
+is definitely annoying, hence ORB will advise all functions in
+this list to return nil to trick `org-capture' and get rid of the
+prompt.
 
 The default value is `(org-bibtex-store-link)', which means this
 function will be ignored and `org-ref-bibtex-store-link' will be


### PR DESCRIPTION
When creating a non-bibtex note, it throws with the following error:

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  string-match("[\\\"]\\| " nil)
  #f(compiled-function (str) #<bytecode 0x334e725>)(nil)
  mapconcat(#f(compiled-function (str) #<bytecode 0x334e725>) (nil) " ")
  combine-and-quote-strings((nil))
  org-roam-add-property(nil "ROAM_REFS")
  (save-excursion (org-roam-add-property orb--current-citekey "ROAM_REFS"))
  orb--add-ref()
  run-hooks(org-roam-capture-new-node-hook)
  org-roam-capture--goto-location()
  org-roam-capture--get-point()
  org-capture-set-target-location(nil)
  org-capture(nil nil)
  org-roam-capture-(:node #s(org-roam-node :file nil :file-hash nil :file-atime nil :file-mtime nil :id nil :level nil :point nil :todo nil :priority nil :scheduled nil :deadline nil :title "hello" :properties nil :olp nil :tags nil :aliases nil :refs nil) :props (:finalize find-file :call-location #<marker at 129689 in README.org>))
  org-roam-node-find()
  funcall-interactively(org-roam-node-find)
  call-interactively(org-roam-node-find nil nil)
  command-execute(org-roam-node-find)
```

This happens because orb--current-citekey is nil but orb still tries
to set it to ROAM_REFS.

Add a conditional check, so orb does not interfere with non-bibtex
notes.