### PR TITLE
Remove org-ref package requires

### DIFF
--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -226,7 +226,6 @@ used to store a link to the BibTeX buffer.  See
   :group 'org-roam-bibtex)
 
 (defcustom orb-insert-interface 'generic
-  ;; BD I think this can go, or else you can just default to org-cite
   "Interface frontend to use with `orb-insert-link'.
 Possible values are the symbols `helm-bibtex', `ivy-bibtex' and
 `generic'.  In the first two cases the respective commands will
@@ -280,7 +279,6 @@ Possible values are `key' and `entry'."
           (const entry)))
 
 (defcustom orb-note-actions-interface 'default
-  ;; BD not sure on this. There are different options.
   "Interface frontend for `orb-note-actions'.
 Supported values (interfaces) are 'default, 'ido, 'hydra, 'ivy and 'helm.
 
@@ -319,9 +317,6 @@ is executed upon selecting it."
     ("Show record in the bibtex file" . bibtex-completion-show-entry))
   "Default actions for `orb-note-actions'.
 Each action is a cons cell DESCRIPTION . FUNCTION."
-  ;; BD these actions are supported in both the WIP 'org-ref-cite'
-  ;; hydra "follow processor" and the bibtex-actions 'embark-act'-based one.
-  ;; Do you need it?
   :risky t
   :type '(alist
           :tag "Default actions for `orb-note-actions'"
@@ -334,8 +329,6 @@ Each action is a cons cell DESCRIPTION . FUNCTION."
     ("Run Orb PDF Scrapper" . orb-note-actions-scrap-pdf))
   "Extra actions for `orb-note-actions'.
 Each action is a cons cell DESCRIPTION . FUNCTION."
-  ;; BD here's an extension point. Maybe the follow processors in 'org-ref-cite'
-  ;; and 'bibtex-actions' need similar?
   :risky t
   :type '(alist
           :tag "Extra actions for `orb-note-actions'"
@@ -346,7 +339,6 @@ Each action is a cons cell DESCRIPTION . FUNCTION."
 (defcustom orb-note-actions-user nil
   "User actions for `orb-note-actions'.
 Each action is a cons cell DESCRIPTION . FUNCTION."
-  ;; BD note sure about this.
   :risky t
   :type '(alist
           :tag "User actions for `orb-note-actions'"
@@ -654,7 +646,6 @@ Returns the new plist."
 (defun orb-insert--link (node info)
   "Insert a link to NODE.
 INFO contains additional information."
-  ;; BD this needs to be OC-ified
   ;; citekey &optional description lowercase region-text beg end
   (-let (((&plist :region :orb-link-description :orb-citekey) info))
     (when region
@@ -814,7 +805,6 @@ the \"Edit note & insert a link\" action.
 When using `orb-insert-generic', a simple list of available
 citation keys is presented using `completion-read' and after
 choosing a candidate the appropriate link will be inserted."
-  ;; BD also needs to be OC-ified
   (interactive "P")
   ;; parse arg
   ;; C-u or C-u C-u C-u => force lowercase
@@ -896,9 +886,6 @@ choosing a candidate the appropriate link will be inserted."
   ;; we don't use candidates here because for a nice hydra we need each
   ;; group of completions separately (default, extra, user), so just
   ;; silence the compiler
-  ;; BD this can stay, but we need to figure out how to make they
-  ;; actions available in different UIs: embark-act, the org-ref-cite
-  ;; hydra, etc. I will raise this as an issue on org-ref-cite.
   (ignore candidates)
   (let ((k ?a)
         actions)

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -8,9 +8,10 @@
 ;; URL: https://github.com/org-roam/org-roam-bibtex
 ;; Keywords: bib, hypermedia, outlines, wp
 ;; Version: 0.6.0
-;; Package-Requires: ((emacs "27.2") (org-roam "2.0.0") (bibtex-completion "2.0.0") (org-ref "1.1.1"))
+;; Package-Requires: ((emacs "27.2") (org-roam "2.0.0") (bibtex-completion "2.0.0"))
 
-;; Soft dependencies: projectile, persp-mode, helm, ivy, hydra
+;; Soft dependencies: projectile, persp-mode, helm, ivy, hydra, org-ref,
+;; org-cite (Org 9.5)
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -226,6 +226,7 @@ used to store a link to the BibTeX buffer.  See
   :group 'org-roam-bibtex)
 
 (defcustom orb-insert-interface 'generic
+  ;; BD I think this can go, or else you can just default to org-cite
   "Interface frontend to use with `orb-insert-link'.
 Possible values are the symbols `helm-bibtex', `ivy-bibtex' and
 `generic'.  In the first two cases the respective commands will
@@ -279,6 +280,7 @@ Possible values are `key' and `entry'."
           (const entry)))
 
 (defcustom orb-note-actions-interface 'default
+  ;; BD not sure on this. There are different options.
   "Interface frontend for `orb-note-actions'.
 Supported values (interfaces) are 'default, 'ido, 'hydra, 'ivy and 'helm.
 
@@ -317,6 +319,9 @@ is executed upon selecting it."
     ("Show record in the bibtex file" . bibtex-completion-show-entry))
   "Default actions for `orb-note-actions'.
 Each action is a cons cell DESCRIPTION . FUNCTION."
+  ;; BD these actions are supported in both the WIP 'org-ref-cite'
+  ;; hydra "follow processor" and the bibtex-actions 'embark-act'-based one.
+  ;; Do you need it?
   :risky t
   :type '(alist
           :tag "Default actions for `orb-note-actions'"
@@ -329,6 +334,8 @@ Each action is a cons cell DESCRIPTION . FUNCTION."
     ("Run Orb PDF Scrapper" . orb-note-actions-scrap-pdf))
   "Extra actions for `orb-note-actions'.
 Each action is a cons cell DESCRIPTION . FUNCTION."
+  ;; BD here's an extension point. Maybe the follow processors in 'org-ref-cite'
+  ;; and 'bibtex-actions' need similar?
   :risky t
   :type '(alist
           :tag "Extra actions for `orb-note-actions'"
@@ -339,6 +346,7 @@ Each action is a cons cell DESCRIPTION . FUNCTION."
 (defcustom orb-note-actions-user nil
   "User actions for `orb-note-actions'.
 Each action is a cons cell DESCRIPTION . FUNCTION."
+  ;; BD note sure about this.
   :risky t
   :type '(alist
           :tag "User actions for `orb-note-actions'"
@@ -646,6 +654,7 @@ Returns the new plist."
 (defun orb-insert--link (node info)
   "Insert a link to NODE.
 INFO contains additional information."
+  ;; BD this needs to be OC-ified
   ;; citekey &optional description lowercase region-text beg end
   (-let (((&plist :region :orb-link-description :orb-citekey) info))
     (when region
@@ -805,6 +814,7 @@ the \"Edit note & insert a link\" action.
 When using `orb-insert-generic', a simple list of available
 citation keys is presented using `completion-read' and after
 choosing a candidate the appropriate link will be inserted."
+  ;; BD also needs to be OC-ified
   (interactive "P")
   ;; parse arg
   ;; C-u or C-u C-u C-u => force lowercase
@@ -886,6 +896,9 @@ choosing a candidate the appropriate link will be inserted."
   ;; we don't use candidates here because for a nice hydra we need each
   ;; group of completions separately (default, extra, user), so just
   ;; silence the compiler
+  ;; BD this can stay, but we need to figure out how to make they
+  ;; actions available in different UIs: embark-act, the org-ref-cite
+  ;; hydra, etc. I will raise this as an issue on org-ref-cite.
   (ignore candidates)
   (let ((k ?a)
         actions)


### PR DESCRIPTION
I decided to open this as a draft PR. It includes two commits ATM; to:

1. to replace `org-ref` in `package-requires with `org-mode "9.5"` (though maybe better to just remove it?)
2. comments, prefaced with "BD ", on the rest of the code of what I think would be required to adapt ORB to org-cite.

I was thinking could be a basis of discussion, and I could drop the second commit if you wanted to remove the `org-ref` requirement in the meantime.

--------------------

## Follow processors?

The most interesting question is WTD about a possible follow processor, which is the UI that would integrate with `org-open-at-point`.

EDIT: actually, there are two questions; whether to do one (or more), and for what targets? I was assuming citations here, but could also be note links or some such.

For sure you _could_ do an ORB one.

But I wonder if we could find a way to have your action extension capability available in other obvious follow processors:

1. `bibtex-actions` has one for `embark-act`
2. `org-ref-cite` has a hydra
3. I think @tmalsburg is working on one for `helm-bibtex`, I believe using helm actions

For **1**, I have an embark "target-finder" for org-cite citations and citation-references, so I am pretty sure all that is required is to write your own keymap and register that with embark.

```elisp
(add-to-list 'embark-keymap-alist '(oc-citation . oc-orb-map))
```
That should expose the commands in `embark-act`, along with any other commands registered with that `oc-citation` category.

For **2**, see https://github.com/jkitchin/org-ref-cite/issues/4.