### PR TITLE
Ensure bibtex-completion is initialized

### DIFF
--- a/orb-utils.el
+++ b/orb-utils.el
@@ -370,6 +370,7 @@ display can be tweaked in the `bibtex-completion-display-formats'
 variable."
   ;; NOTE: A drop-in replacement for `org-ref-format-entry' which was removed
   ;; in Org-ref v3.  Still waiting for a native solution.
+  (bibtex-completion-init)
   (bibtex-completion-format-entry
    (bibtex-completion-get-entry citekey) (1- (frame-width))))
 

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -854,7 +854,6 @@ This function is not interactive, set `orb-insert-interface' to
 If ARG is non-nil, rebuild `bibtex-completion-cache'."
   (when arg
     (bibtex-completion-clear-cache))
-  (bibtex-completion-init)
   (let* ((candidates (bibtex-completion-candidates))
          (candidates2
           (if (eq orb-insert-generic-candidates-format 'key)
@@ -1149,6 +1148,7 @@ interactively."
          (add-to-list 'bibtex-completion-key-at-point-functions #'orb-get-node-citekey)
          (add-hook 'org-capture-after-finalize-hook #'orb-make-notes-cache)
          (add-hook 'org-roam-capture-new-node-hook #'orb--insert-captured-ref-h)
+         (bibtex-completion-init)
          (orb-make-notes-cache))
         (t
          (dolist (var-alist orb--external-vars-original-values)

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -1148,6 +1148,7 @@ interactively."
          (add-to-list 'bibtex-completion-key-at-point-functions #'orb-get-node-citekey)
          (add-hook 'org-capture-after-finalize-hook #'orb-make-notes-cache)
          (add-hook 'org-roam-capture-new-node-hook #'orb--insert-captured-ref-h)
+         ;; HACK: temporary to address #256; see also `orb-format-entry'
          (bibtex-completion-init)
          (orb-make-notes-cache))
         (t


### PR DESCRIPTION
`bibtex-completion-format-entry` fails if `bibtex-completion-display-formats-internal` is `nil`, which is the case if bibtex completion has not been initialized via `(bibtex-completion-init)` and I run `orb-note-actions`.

This happened to me because I install `bibtex-completion` via `straight.el` without `helm-bibtex` or `ivy-bibtex`. Calling commands of either of those packages seems to initialize it. When it is not initialized, that resulted in the error message

    s-format: Wrong type argument: arrayp, nil

because `bibtex-completion-format-entry` then tries to format a `nil` string.

Calling `(bibtex-completion-init)` seems to be cheap after subsequent invocations, but I'm not sure that calling it in every `orb-format-entry` is the best solution or we can somehow make sure to call it only once. But that function call also present in `orb-insert-generic`, so I assume it's no problem. Anyway, this fixed my issues.