### PR TITLE
add three initial org-roam-mode-buffer sections for orb

### DIFF
--- a/orb-section.el
+++ b/orb-section.el
@@ -1,0 +1,159 @@
+;;; orb-section.el --- Org Roam BibTeX: Sections for org-roam-mode -*- lexical-binding: t -*-
+
+;; Copyright © 2022 Samuel W. Flint
+
+;; Author: Samuel W. Flint <swflint@flintfam.org>
+
+;; URL: https://github.com/org-roam/org-roam-bibtex
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; see the file LICENSE.  If not, visit
+;; <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; This file provides org-roam-bibtex' dependencies and thus should
+;; normally be required by org-roam-bibtex feature libraries.  It
+;; defines customize groups and provides general utility functions
+;; that depend on extra features provided through org-roam,
+;; bibtex-completion and their dependencies.
+
+;;; Code:
+
+;; ============================================================================
+;;; Dependencies
+;; ============================================================================
+
+(require 'org-roam-node)
+(require 'org-roam-utils)
+(require 's)
+(require 'magit-section)
+(require 'bibtex-completion)
+
+
+;; ============================================================================
+;;; Configuration Variables
+;; ============================================================================
+
+(defgroup orb-section nil
+  "Org-roam buffer sections for BibTeX."
+  :group 'org-roam-bibtex
+  :prefix "orb-section-")
+
+(defcustom orb-section-reference-format-method 'bibtex-completion-apa-format-reference
+  "How to format the ORB citation.  Either a function taking a
+bibtex key and returning a string, or an alist from type to
+format string.  For formatting information, see
+`bibtex-completion-display-formats'."
+  :type '(choice (const :tag "Use BibTeX-Completion APA Format" 'bibtex-completion-apa-format-reference)
+                 (symbol :tag "Use a function")
+                 (alist :key-type   (choice (string :tag "Type Name    :")
+                                            (const :tag "Default" t))
+                        :value-type (string :tag "Format String:"))))
+
+(defcustom orb-section-abstract-format-method :org-format
+  "How to format ORB abstract.  A function taking a key and
+returning a string, or one of:
+
+ - `:org-format' Assume that the content is org-formatted, and
+   format accordingly.
+ - `:pandoc-from-tex' Assume that the content is tex/latex
+   formatted and use `pandoc' to format accordingly."
+  :type '(choice (const :tag "Format as Org Text" :org-format)
+                 (const :tag "Format from LaTeX" :pandoc-from-tex)
+                 (symbol :tag "Use function.")))
+
+
+;; ============================================================================
+;;; Utility functions
+;; ============================================================================
+
+(defun orb-section-reference-format (key)
+  "Format reference for KEY according to `orb-section-citation-format-method'."
+  (if (functionp orb-section-reference-format-method)
+      (funcall orb-section-reference-format-method key)
+    (when-let ((entry (bibtex-completion-get-entry key))
+               (format-string (cdr (or (assoc-string (bibtex-completion-get-value "=type=" entry) orb-section-reference-format-method)
+                                       (assoc t orb-section-reference-format-method))))
+               (formated-reference (s-format format-string 'bibtex-completion-apa-get-value entry)))
+      (replace-regexp-in-string "\\([.?!]\\)\\." "\\1" formatted-reference))))
+
+(defun orb-section-abstract-format (key)
+  "Format abstract for KEY per `orb-section-abstract-format-method'."
+  (if (functionp orb-section-abstract-format-method)
+      (funcall orb-section-abstract-format-method key)
+    (when-let ((entry (bibtex-completion-get-entry key))
+               (abstract (bibtex-completion-get-value "abstract" entry)))
+      (pcase orb-section-abstract-format-method
+        (:org-format
+         (org-roam-fontify-like-in-org-mode
+          (with-temp-buffer
+            (insert abstract)
+            (org-mode)
+            (unfill-region (point-min) (point-max))
+            (save-match-data "\n\n" "\n" (string-trim (buffer-string))))))
+        (:pandoc-from-tex
+         (org-roam-fontify-like-in-org-mode
+          (with-temp-buffer
+            (insert abstract)
+            (shell-command-on-region (point-min) (point-max)
+                                     "pandoc -f latex -t org" (current-buffer) t)
+            (org-mode)
+            (unfill-region (point-min) (point-max))
+            (save-match-data "\n\n" "\n" (string-trim (buffer-string))))))))))
+
+
+;; ============================================================================
+;;; Section Implementation
+;; ============================================================================
+
+(defun orb-section-reference (node)
+  "Show BibTeX reference for NODE if it exists."
+  (when-let ((node-refs (org-roam-node-refs node))
+             (cite-key (first node-refs))
+             (formatted-reference (orb-section-reference-format cite-key)))
+    (magit-insert-section (orb-section-reference)
+      (magit-insert-heading "Reference:")
+      (insert formatted-reference)
+      (insert "\n\n"))))
+
+(defun orb-section-abstract (node)
+  "Show BibTeX entry abstract for NODE if it exists."
+  (when-let ((node-refs (org-roam-node-refs node))
+             (cite-key (first node-refs))
+             (formatted-abstract (orb-abstract-format cite-key)))
+    (magit-insert-section (orb-section-abstract)
+      (magit-insert-heading "Abstract:")
+      (insert formatted-abstract)
+      (insert "\n\n"))))
+
+(defun orb-section-file (node)
+  "Show a link to entry file for NODE if it exists."
+  (when-let ((node-refs (org-roam-node-refs node))
+             (cite-key (first node-refs))
+             (file-name (let ((orb-abbreviate-file-name nil))
+                          (orb-get-atached-file cite-key))))
+    (magit-insert-section (orb-section-file)
+      (magit-insert-heading "File:")
+      (insert-text-button (file-name-nondirectory file-name)
+                          'action (lambda (button) (find-file file-name)))
+      (insert "\n\n"))))
+
+(provide 'orb-section)
+
+;; Local Variables:
+;; coding: utf-8
+;; fill-column: 79
+;; End:

--- a/orb-utils.el
+++ b/orb-utils.el
@@ -353,15 +353,15 @@ Return Org Roam node or nil."
 If optional NODE is nil, return the citekey for node at point.
 ASSERT will be passed to `org-roam-node-at-point'.  If it is
 non-nil, an error will be thrown if there is no node at point."
-  (when-let ((node (or node (org-roam-node-at-point assert))))
-    (save-excursion
-      (goto-char (org-roam-node-point node))
-      (let* ((prop (org-entry-get (point) "ROAM_REFS"))
-             (prop-list (when prop (split-string-and-unquote prop))))
-        (catch 'found
-          (dolist (p prop-list)
-            (when (string-match orb-utils-citekey-re p)
-              (throw 'found (match-string 1 p)))))))))
+  (when-let ((node (or node (org-roam-node-at-point assert)))
+             (node-refs (cdr (assoc-string
+                              "ROAM_REFS"
+                              (org-roam-node-properties node) t))))
+    (let* ((ref-list (split-string-and-unquote node-refs)))
+      (catch 'found
+        (dolist (ref ref-list)
+          (when (string-match orb-utils-citekey-re ref)
+            (throw 'found (match-string 1 ref))))))))
 
 (defun orb-format-entry (citekey)
   "Format a BibTeX entry for display, whose citation key is CITEKEY.


### PR DESCRIPTION
Sections are:

 - `orb-section-reference` which shows a formatted reference.
 - `orb-section-abstract` which shows the abstract.
 - `orb-section-file` which provides a link to the file.