### PR TITLE
Set required bibtex-completion version to 1.0.0

### DIFF
--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -8,7 +8,7 @@
 ;; URL: https://github.com/org-roam/org-roam-bibtex
 ;; Keywords: bib hypermedia outlines wp
 ;; Version: 0.6.1
-;; Package-Requires: ((emacs "27.1") (org-roam "2.2.0") (bibtex-completion "2.0.0"))
+;; Package-Requires: ((emacs "27.1") (org-roam "2.2.0") (bibtex-completion "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
This PR sets the required version of `bibtex-completion` from 2.0.0 to 1.0.0, since version 2.0.0 does not exist as far as i can tell and the wrong version requirement causes problems (see https://github.com/progfolio/elpaca/issues/263).

